### PR TITLE
Rename CI job

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-name: validate pull request
+name: ci-unit-tests
 
 on:
   pull_request:


### PR DESCRIPTION
Github isn't letting me add it as a branch protection requirement, and I'm hoping it's because of the spaces in the name