### PR TITLE
Update contributing docs with EF installation/migrations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,10 @@ To run these dependencies, simply do
 docker-compose up
 ```
 
+If it's your first time setting up the database you will need to apply the Database migrations by running the entity framework tools.
+
+This processes is documented in [Letterbook.Adapter.Db](Letterbook.Adapter.Db/readme.md).
+
 ## License
 
 Letterbook is licensed under the [AGPL, version 3.0][license]. The maintainers may, at our discretion, change the license to any future version. Anyone who contributes to the project must do so under the same terms. That is, you are licensing your work to the project and the other contributors under that same license and any future version as becomes necessary.

--- a/Letterbook.Adapter.Db/readme.md
+++ b/Letterbook.Adapter.Db/readme.md
@@ -1,4 +1,12 @@
-﻿# Migrations
+﻿# Setup Entity Framework
+
+Install the [Entity Framework Core CLI tools](https://learn.microsoft.com/en-us/ef/core/cli/dotnet).
+
+```shell
+dotnet tool install --global dotnet-ef
+```
+
+# Migrations
 
 To generate a new migration:
 ```shell


### PR DESCRIPTION
discuss installing and setting up Entity Framework in the contributing docs and setting up the EF tooling from a clean dotnet install.