### PR TITLE
Add OTel, Prometheus and Grafana

### DIFF
--- a/Letterbook.Api/Letterbook.Api.csproj
+++ b/Letterbook.Api/Letterbook.Api.csproj
@@ -23,6 +23,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.6.0-rc.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.6.0-beta.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/Letterbook.Api/Program.cs
+++ b/Letterbook.Api/Program.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
+using OpenTelemetry.Metrics;
 
 namespace Letterbook.Api;
 
@@ -47,6 +48,14 @@ public class Program
                 };
                 // TODO(Security): Figure out how to do this only in Development
                 options.RequireHttpsMetadata = false;
+            });
+        
+        // Register Open Telemetry
+        builder.Services.AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics.AddAspNetCoreInstrumentation();
+                metrics.AddPrometheusExporter();
             });
 
         // Register options
@@ -122,6 +131,8 @@ public class Program
 
         app.UseAuthentication();
         app.UseAuthorization();
+
+        app.MapPrometheusScrapingEndpoint();
         
         app.UsePathBase(new PathString("/api/v1"));
 

--- a/Letterbook.Dashboards/Grafana/provisioning/datasources/prometheus.yml
+++ b/Letterbook.Dashboards/Grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,7 @@
+﻿apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090/

--- a/Letterbook.Dashboards/Prometheus/prometheus.yml
+++ b/Letterbook.Dashboards/Prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+﻿scrape_configs:
+  - job_name: 'letterbook'
+    
+    metrics_path: /metrics
+    scheme: http
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['host.docker.internal:5127'] # host.docker.internal maps the host machine to the internal docker network

--- a/Letterbook.Dashboards/README.md
+++ b/Letterbook.Dashboards/README.md
@@ -1,0 +1,21 @@
+﻿# Dashboards
+
+This is a set of configurations and settings for prometheus and grafana monitoring services.
+
+These settings are used by the default monitors configured in the [Docker Compose](../docker-compose.yml) file.
+
+
+
+## Grafana
+
+Grafana is available at [localhost:3000](localhost:3000) and will use the default `admin` user with a default password
+of `admin`. Once you connect you will be prompted to set a new password.
+
+Grafana should automatically provision a connection to the local Prometheus data source.
+
+## Prometheus
+
+Prometheus is configured with [prometheus.yml](Letterbook.Dashboards/Prometheus/prometheus.yml) to connect to a local
+version of Letterbook running on your host computer. If you are running Letterbook on another port or in any other way
+this connection may not work out of the box and your configuration may need to be updated for prometheus scrapping to
+work correctly.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 ﻿
 
 services:
+  # Services required for Letterbook operation
   timescale:
     container_name: timescale
     image: timescale/timescaledb:2.11.2-pg15-oss
@@ -22,3 +23,21 @@ services:
     ports:
       - "5432:5432"
     restart: always
+
+  # Optional Dashboarding and Observability Services
+  grafana:
+      container_name: grafana
+      image: grafana/grafana-oss:10.2.0
+      ports:
+        - "3000:3000"
+      volumes:
+        - "./Letterbook.Dashboards/Grafana/provisioning:/etc/grafana/provisioning"
+        
+  prometheus:
+      container_name: prometheus
+      image: prom/prometheus:v2.47.2
+      # network_mode: "host"
+      ports:
+        - "9090:9090" # Not used since this is using Host mode
+      volumes:
+        - "./Letterbook.Dashboards/Prometheus/prometheus.yml:/etc/prometheus/prometheus.yml"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,7 @@ services:
   prometheus:
       container_name: prometheus
       image: prom/prometheus:v2.47.2
-      # network_mode: "host"
       ports:
-        - "9090:9090" # Not used since this is using Host mode
+        - "9090:9090"
       volumes:
         - "./Letterbook.Dashboards/Prometheus/prometheus.yml:/etc/prometheus/prometheus.yml"


### PR DESCRIPTION
Adding ASP.NET core telemetry and configuring basic prometheus + grafana endpoints. This should get us to the point where we can start recording and observing metrics, intended as a starting point for this work. By default we'll get a record of a the duration of web requests in milli's. The default behavior is discussed in more depth [here](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Instrumentation.AspNetCore/README.md).

The `provisioning/dashboards` path is kept around for future use in automatic dashboard provisioning. Implementing that now isn't super useful though since telemetry is limited.

## Details
- This introduces two new containers started w/ the project: Prometheus and Grafana. This is sensitive to the port you're running the project on and can break if that changes.
- Open Telemetry Metrics are a still an [experimental feature](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/telemetry-stability.md). There might be some turbulence as a result of this depending on how this evolves.
