### PR TITLE
Add Loki Logging

### DIFF
--- a/Letterbook.Api/Letterbook.Api.csproj
+++ b/Letterbook.Api/Letterbook.Api.csproj
@@ -28,6 +28,8 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.6.0-beta.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.1" />
+    <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="8.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/Letterbook.Api/Letterbook.Api.csproj
+++ b/Letterbook.Api/Letterbook.Api.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.6.0-beta.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Serilog.Expressions" Version="4.0.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="7.0.1" />
     <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="8.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />

--- a/Letterbook.Api/appsettings.Development.json
+++ b/Letterbook.Api/appsettings.Development.json
@@ -47,17 +47,24 @@
     "Enrich": [
       "FromLogContext"
     ],
-    "Filter": [
-      {
-        "Name": "ByExcluding",
-        "Args": {
-          "expression": "RequestPath like '/metrics'"
-        }
-      }
-    ],
     "WriteTo": [
       {
-        "Name": "Console"
+        "Name": "Logger",
+        "Args": {
+          "configureLogger": {
+            "Filter": [
+              {
+                "Name": "ByExcluding",
+                "Args": {
+                  "expression": "RequestPath like '/metrics'"
+                }
+              }
+            ],
+            "WriteTo": {
+              "Name": "Console"
+            }
+          }
+        }
       },
       {
         "Name": "GrafanaLoki",

--- a/Letterbook.Api/appsettings.Development.json
+++ b/Letterbook.Api/appsettings.Development.json
@@ -30,5 +30,41 @@
         "SingleLine": true
       }
     }
+  },
+  "Serilog": {    
+    "Using": [
+      "Serilog.Sinks.Console",
+      "Serilog.Sinks.Grafana.Loki"
+    ],
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
+    }, 
+    "Enrich": [
+      "FromLogContext"
+    ],
+    "WriteTo": [
+      {
+        "Name": "Console"
+      },
+      {
+        "Name": "GrafanaLoki",
+        "Args": {
+          "uri": "http://localhost:3100",
+          "labels": [
+            {
+              "key": "app",
+              "value": "letterbook"
+            }
+          ],
+          "propertiesAsLabels": [
+            "app"
+          ]
+        }
+      }
+    ]
   }
 }

--- a/Letterbook.Api/appsettings.Development.json
+++ b/Letterbook.Api/appsettings.Development.json
@@ -34,6 +34,7 @@
   "Serilog": {    
     "Using": [
       "Serilog.Sinks.Console",
+      "Serilog.Expressions",
       "Serilog.Sinks.Grafana.Loki"
     ],
     "MinimumLevel": {
@@ -45,6 +46,14 @@
     }, 
     "Enrich": [
       "FromLogContext"
+    ],
+    "Filter": [
+      {
+        "Name": "ByExcluding",
+        "Args": {
+          "expression": "RequestPath like '/metrics'"
+        }
+      }
     ],
     "WriteTo": [
       {

--- a/Letterbook.Api/appsettings.json
+++ b/Letterbook.Api/appsettings.json
@@ -5,12 +5,5 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "Serilog": {
-    "MinimumLevel": "Information",
-    "WriteTo": [
-      { "Name": "Console" }
-    ],
-    "Enrich": [ "FromLogContext" ]
-  },
   "AllowedHosts": "*"
 }

--- a/Letterbook.Dashboards/Grafana/provisioning/datasources/loki.yml
+++ b/Letterbook.Dashboards/Grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,7 @@
+﻿apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,30 +27,44 @@ services:
     volumes:
       - letterbook_db_data:/var/lib/postgresql/data
     restart: always
+
+  # Optional Dashboarding and Observability Services 
+  loki:
+    container_name: loki
+    image: grafana/loki:latest
+    ports:
+      - "3100:3100"
+    restart: unless-stopped
     
   httpbin:
     container_name: httpbin
     image: kennethreitz/httpbin
     ports:
       - '8200:80'
+    restart: unless-stopped
   
   # Optional Dashboarding and Observability Services
-  grafana:
-      container_name: grafana
-      image: grafana/grafana-oss:10.2.0
-      ports:
-        - "3000:3000"
-      volumes:
-        - "./Letterbook.Dashboards/Grafana/provisioning:/etc/grafana/provisioning"
-        
+  grafana:    
+    depends_on:
+      - loki
+      - prometheus
+    container_name: grafana
+    image: grafana/grafana-oss:10.2.0
+    ports:
+      - "3000:3000"
+    volumes:
+      - "./Letterbook.Dashboards/Grafana/provisioning:/etc/grafana/provisioning"
+    restart: unless-stopped
+    
   prometheus:
-      container_name: prometheus
-      image: prom/prometheus:v2.47.2
-      ports:
-        - "9090:9090"
-      volumes:
-        - "./Letterbook.Dashboards/Prometheus/prometheus.yml:/etc/prometheus/prometheus.yml"
-
+    container_name: prometheus
+    image: prom/prometheus:v2.47.2
+    ports:
+      - "9090:9090"
+    volumes:
+      - "./Letterbook.Dashboards/Prometheus/prometheus.yml:/etc/prometheus/prometheus.yml"
+    restart: unless-stopped
+    
 volumes:
   letterbook_db_data:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,6 @@ services:
       - '8200:80'
     restart: unless-stopped
   
-  # Optional Dashboarding and Observability Services
   grafana:    
     depends_on:
       - loki


### PR DESCRIPTION
This introduces [Grafana Loki](https://grafana.com/docs/loki/latest/) and connects the logs of `Letterbook.API` to `Grafana` so they can be read.

This will allow us to view app logs in Grafana and configure alerts for them.

Testing this:

1. run `docker-compose`
1. run `Letterbook.API`
1. open Grafana at `localhost:3000`
1. Open your [data sources](http://localhost:3000/connections/datasources)
1. Select `Explore` on Loki.