### PR TITLE
Add ability to query postgres db's in grafana.

### DIFF
--- a/Letterbook.Dashboards/Grafana/provisioning/datasources/postgres.yml
+++ b/Letterbook.Dashboards/Grafana/provisioning/datasources/postgres.yml
@@ -1,0 +1,18 @@
+apiVersion: 1
+
+datasources:
+  - name: Letterbook DB
+    type: postgres
+    url: letterbook_db:5432
+    user: letterbook
+    secureJsonData:
+      password: 'letterbookpw'
+    jsonData:
+      database: letterbook
+      sslmode: 'disable' # disable/require/verify-ca/verify-full
+      maxOpenConns: 100 # Grafana v5.4+
+      maxIdleConns: 100 # Grafana v5.4+
+      maxIdleConnsAuto: true # Grafana v9.5.1+
+      connMaxLifetime: 14400 # Grafana v5.4+
+      postgresVersion: 903 # 903=9.3, 904=9.4, 905=9.5, 906=9.6, 1000=10
+      timescaledb: false

--- a/Letterbook.Dashboards/Grafana/provisioning/datasources/timescale.yml
+++ b/Letterbook.Dashboards/Grafana/provisioning/datasources/timescale.yml
@@ -1,0 +1,18 @@
+apiVersion: 1
+
+datasources:
+  - name: Timescale (Letterbook Timeseries)
+    type: postgres
+    url: timescale:5433
+    user: letterbook
+    secureJsonData:
+      password: 'letterbookpw'
+    jsonData:
+      database: letterbook
+      sslmode: 'disable' # disable/require/verify-ca/verify-full
+      maxOpenConns: 100 # Grafana v5.4+
+      maxIdleConns: 100 # Grafana v5.4+
+      maxIdleConnsAuto: true # Grafana v9.5.1+
+      connMaxLifetime: 14400 # Grafana v5.4+
+      postgresVersion: 903 # 903=9.3, 904=9.4, 905=9.5, 906=9.6, 1000=10
+      timescaledb: true


### PR DESCRIPTION
I don't know if we actually want this but it introduces access for both Postgres DB's in Grafana so queries can be run against tables in both of them. This allows inspecting of those DB's from inside of Grafana and potentially future use for telemetry and usage metrics for the server (ex. dashboards showing most active users).

Part of #116