### PR TITLE
ADR-07: post data model

### DIFF
--- a/Letterbook.Core/Models/Post.cs
+++ b/Letterbook.Core/Models/Post.cs
@@ -1,0 +1,25 @@
+﻿namespace Letterbook.Core.Models;
+
+public class Post
+{
+    public Uri Id { get; set; }
+    public Guid? LocalId { get; set; }
+    public string Authority => Id.Authority;
+    public ICollection<Profile> Creators { get; set; } = new HashSet<Profile>();
+    public DateTime CreatedDate { get; set; }
+    public ICollection<IContent> Contents { get; set; } = new HashSet<IContent>();
+    public ICollection<Audience> Visibility { get; set; } = new HashSet<Audience>();
+    public ICollection<Mention> AddressedTo { get; set; } = new HashSet<Mention>();
+    public string? Client { get; set; }
+    public Post? InReplyTo { get; set; }
+    public Uri? Replies { get; set; }
+    public IList<Post> RepliesCollection { get; set; } = new List<Post>();
+    public Uri? Likes { get; set; }
+    public IList<Profile> LikesCollection { get; set; } = new List<Profile>();
+    public Uri? Shares { get; set; }
+    public IList<Profile> SharesCollection { get; set; } = new List<Profile>();
+}
+
+public interface IContent
+{
+}

--- a/Letterbook.Core/Models/Post.cs
+++ b/Letterbook.Core/Models/Post.cs
@@ -8,7 +8,7 @@ public class Post
     public ICollection<Profile> Creators { get; set; } = new HashSet<Profile>();
     public DateTime CreatedDate { get; set; }
     public ICollection<IContent> Contents { get; set; } = new HashSet<IContent>();
-    public ICollection<Audience> Visibility { get; set; } = new HashSet<Audience>();
+    public ICollection<Audience> Audience { get; set; } = new HashSet<Audience>();
     public ICollection<Mention> AddressedTo { get; set; } = new HashSet<Mention>();
     public string? Client { get; set; }
     public Post? InReplyTo { get; set; }

--- a/Letterbook.sln
+++ b/Letterbook.sln
@@ -43,6 +43,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Decisions", "Decisions", "{
 		docs\decisions\01-system-design-guidance.md = docs\decisions\01-system-design-guidance.md
 		docs\decisions\02-architecture-design-patterns.md = docs\decisions\02-architecture-design-patterns.md
 		docs\decisions\hexagonal-architecture.png = docs\decisions\hexagonal-architecture.png
+		docs\decisions\03-accounts-profiles-actors.md = docs\decisions\03-accounts-profiles-actors.md
+		docs\decisions\05-integration-tests.md = docs\decisions\05-integration-tests.md
+		docs\decisions\06-code-review.md = docs\decisions\06-code-review.md
+		docs\decisions\07-posts-data-model.md = docs\decisions\07-posts-data-model.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Letterbook.Adapter.RxMessageBus", "Letterbook.Adapter.RxMessageBus\Letterbook.Adapter.RxMessageBus.csproj", "{FD68DA55-DCCF-4F8B-AFBB-C1383E9C58A0}"

--- a/docs/decisions/07-posts-data-model.md
+++ b/docs/decisions/07-posts-data-model.md
@@ -1,6 +1,6 @@
 ﻿# Data Model for Generic Posts
 
-We can expect almost any of the ActivityStreams Object types to federate in a way that resembles a post. And we will want to do the same eventually; we don't need to limit ourselves to just Notes. This offers a way to represent posts in a timeline, thread, etc as a generic container for their content.
+We can expect almost any of the ActivityStreams Object types to federate in a way that resembles a post. And we will want to do the same eventually; we don't need to limit ourselves to just Notes. This offers a way to represent posts in a timeline, thread, etc independently of their specific content.
 
 ## Status
 
@@ -11,53 +11,152 @@ We can expect almost any of the ActivityStreams Object types to federate in a wa
 
 # Decision
 
-A summary of what was proposed and decided
+The basic idea is to decouple the posts that make up a feed or thread from their content. We define a `Post` type, which is a container for specialty content that would populate the post. We would start with `Notes` and `Images` as content, but other types like `Polls`, `Events`, `Articles`, and so on would be supported in the future. Each content record can belong to at most 1 Post. Here's a simplified model of what those relations look like. `Profile` and `Audience` already exist and would be essentially unchanged.
 
 ```mermaid
 erDiagram
-    Note 1 -- zero or one Post : posted
-    Image 1+ -- 0+ Post : posted
-    Etc 1+ -- 0+ Post : posted
+    Note zero or one -- one Post : posted
+    Image 0+ -- one Post : posted
+    Etc 0+ -- one Post : posted
     Post 0+ -- 1+ Profile : created-by
     Post 0+ -- 0+ Profile : liked-by
     Post 0+ -- 0+ Profile : shared-by
     Post 0+ -- 0+ Profile: addressed-to
+    Post 0+ -- 0+ Audience : visible-to
     Post 0+ -- zero or one Post : in-reply-to
+    Profile 1+ -- 1+ Audience : member-of
     
     Post {
-        uri id pk
-        uuid localId
-        date created
-        date updated
+        uuid id PK
+        uri uri "indexed"
+        uri thread "indexed"
+        timestamp created
+        timestamp updated
         string client
     }
     
     Note {
-        uuid id pk
-        uri uri
+        uuid id PK
+        uri uri "indexed"
         string summary
         string preview
         string source
     }
     
     Image {
-        uuid id pk
-        uri uri
+        uuid id PK
+        uri uri "indexed"
         string summary
         string preview
         string source
     }
     
+    Etc {
+        uuid id PK
+        uri uri "indexed"
+        string summary
+        string preview
+        string source
+ }
+    
+```
+
+So, everything becomes a post, with some child content items. It doesn't currently happen (much?) in the wild, but this would allow us to easily handle activities that include multiple content-like objects (multiple notes, images, questions, mix-and-match, etc). One other benefit this has is that it makes it easier to assign meaningful IDs to our `Activities`. This is because the post, as a container for its content, will tend to map very easily onto the activity that carried it. The types above are mostly illustrative, not complete or final. The idea is that they would implement an interface, call it `IContent`, which would provide enough information to build a feed of posts. That would 
+
+```mermaid
+classDiagram
+    direction LR
+    class IContent {
+        <<interface>>
+        Uuid Id
+        Uri Uri
+        Uri Thread
+        string? Summary
+        string? Preview
+        string? Source
+        
+        Type() string
+    }
+    
+    class Post {
+        Uuid Id
+        Uri Uri
+        Uri Thread
+        DateTime Created
+        DateTime Updated
+        IList~IContent~ Contents
+        string Client
+    }
+    
+    class Note {
+        string Content
+        Type() "Note"
+    }
+
+    class Image {
+        MediaType MediaType
+        Type() "Image"
+    }
+    
+    class FeedDto {
+        Post Post
+        Profile CreatedBy
+        Profile SharedBy
+        Post InReplyTo
+        Uri Thread
+        Content Content
+    }
+    
+    class Content {
+        Uuid Id
+        Uri Uri
+        Uri Thread
+        string? Summary
+        string? Preview
+        string? Source
+        
+        Type()*
+    }
+
+    Content <|-- Note : inherits
+    Content <|-- Image : inherits
+    Content <|-- Etc : inherits
+    IContent <|-- Content : implements
+    Post --* IContent : contains
+    Post --> FeedDto : maps-to
+    FeedDto --* Content : contains
 ```
 
 ## Impact
 
-Details about what changes because of the decision
+This will obviously introduce some new data types. It's also likely to require some complex migrations. It should ideally happen soon, before any serious work starts on posting-related features.
+
+You may also notice that this data model is more restrictive than what ActivityPub would allow. Notably, Posts can only be InReplyTo at most one other Post (and no other kind of object). A Note can only be in one Post and vice-versa. And because `IContent.Thread` would map to `AS Context`, a post can only have one context and exist in one thread. These restrictions should be fully compatible with the actual behavior of other fedi services in the wild. It helps to narrow the possibility space that we would actually have to deal with, and should support faster queries for the most common cases (when a post is a note and nothing else). This means that there could be potential future fedi peers that we would not be readily compatible with.
 
 ## Context
 
-Information about the situation that prompted the proposal/decision
+The content-related data schema we have now is troublesome to work with, and that will only get worse over time. It was developed quickly, very early in the project, and it was always likely that it wouldn't be viable in the long term. The original schema was useful to provide some anchor points to develop an internal data model that isn't simply replicating all of ActivityPub (a likely impossible task). It also provided a point to iterate from. Now we're iterating, with more care and more context.
+
+For reference, the model we have now is that various classes (`Note` and `Image` at the moment) implement an `IContentRef` interface, and that's kind of it. Those objects can be assigned a resolvable URI based on their types, and those URIs are the critical component of Feed records. To actually use this system in practice, the client would retrieve a batch of records for the feed, and it would consist of little more than URI which it would have to then issue individual follow-up requests to resolve. Which is not great. It's also surprisingly difficult to map AP docs to these objects. I'm not sure this design solves that problem on its own, but I think it does become easier to build a `ContentFactory` or similar, which was likely always going to be necessary. Then we can map them to `Content` objects, as built by the factory, which can handle the logic of deciding what concrete type to construct.
 
 ## Discussion
 
-A summary of the comments/issues/concerns that led up to the decision
+### minor activities
+A Post can have more than one content, and a content item can theoretically exist in more than one post. If a post is `Liked` by someone, should that Like follow the content to other posts? I think probably not, right? For example, suppose you upload a photo, then post that photo with a note. The later you add that photo to an album. Should the view of the photo in the album show all the Likes that the Post received? What if you reuse the photo in another post in the future?
+
+### notes or just post body?
+Is it better to have notes as a content object of the post, or should the note just be sort of body properties on the post? It's probably more complicated to serialize reliably if the post body becomes a note on the wire. But it would save a join for the large majority of records. Sort of. The join is still necessary for the query, because we still need the other content items. But there would be no results from the other joined tables most of the time, and I expect the query planner to handle that efficiently.
+
+### schema
+Making each content record include-able in only one post saves on potentially a _ton_ of many-many joins. This makes it more involved to re-use uploaded media. For example, to reuse the same reaction gif repeatedly. We would need to introduce other models to track those uploads as files, not just post content. But, that seems worth it to me.
+
+We can defer that model design until we start work on the [file/media features](https://github.com/Letterbook/Letterbook/issues/139).
+
+### hypothetical compatibility
+Not attempting to be universally future compatible seems reasonable. It's not like it would be possible anyway. We can work to improve compatibility in the future, if such an incompatible peer service should ever be created.
+
+### need the interface?
+Do we need `IContent`, or is the base/abstract `Content` class enough?
+
+### AS inReplyTo
+AP/AS have some types that are pretty obviously content: `Note`, `Image`, `Document`, `Video`, `Audio`, `Article`, `Page`, `Event`, `Question`. It's not hard to figure out what it means for something to be `inReplyTo` one of those types. But, `Object` is the base type for everything in ActivityStreams, and the spec permits any object to be `inReplyTo` any other object. What does it mean if a `Note` is in reply to a `Collection`, or a `Profile`, or an `Update`? I don't know, and neither do the spec authors. So, we're just not dealing with that. If we ever start receiving federated documents doing that, then we can decide how to handle it. And honestly that might mean we just choose to discard those activities for being incomprehensible to our data model. It seems like that would have to be either a very different app than ours, or just a nonsensical implementation.

--- a/docs/decisions/07-posts-data-model.md
+++ b/docs/decisions/07-posts-data-model.md
@@ -1,0 +1,63 @@
+﻿# Data Model for Generic Posts
+
+We can expect almost any of the ActivityStreams Object types to federate in a way that resembles a post. And we will want to do the same eventually; we don't need to limit ourselves to just Notes. This offers a way to represent posts in a timeline, thread, etc as a generic container for their content.
+
+## Status
+
+- [ ] Decided 
+- [ ] Decided Against 
+- [ ] Deferred 
+- [ ] Superseded 
+
+# Decision
+
+A summary of what was proposed and decided
+
+```mermaid
+erDiagram
+    Note 1 -- zero or one Post : posted
+    Image 1+ -- 0+ Post : posted
+    Etc 1+ -- 0+ Post : posted
+    Post 0+ -- 1+ Profile : created-by
+    Post 0+ -- 0+ Profile : liked-by
+    Post 0+ -- 0+ Profile : shared-by
+    Post 0+ -- 0+ Profile: addressed-to
+    Post 0+ -- zero or one Post : in-reply-to
+    
+    Post {
+        uri id pk
+        uuid localId
+        date created
+        date updated
+        string client
+    }
+    
+    Note {
+        uuid id pk
+        uri uri
+        string summary
+        string preview
+        string source
+    }
+    
+    Image {
+        uuid id pk
+        uri uri
+        string summary
+        string preview
+        string source
+    }
+    
+```
+
+## Impact
+
+Details about what changes because of the decision
+
+## Context
+
+Information about the situation that prompted the proposal/decision
+
+## Discussion
+
+A summary of the comments/issues/concerns that led up to the decision

--- a/docs/decisions/07-posts-data-model.md
+++ b/docs/decisions/07-posts-data-model.md
@@ -141,8 +141,6 @@ For reference, the model we have now is that various classes (`Note` and `Image`
 
 ## Discussion
 
-### minor activities
-A Post can have more than one content, and a content item can theoretically exist in more than one post. If a post is `Liked` by someone, should that Like follow the content to other posts? I think probably not, right? For example, suppose you upload a photo, then post that photo with a note. The later you add that photo to an album. Should the view of the photo in the album show all the Likes that the Post received? What if you reuse the photo in another post in the future?
 
 ### notes or just post body?
 Is it better to have notes as a content object of the post, or should the note just be sort of body properties on the post? It's probably more complicated to serialize reliably if the post body becomes a note on the wire. But it would save a join for the large majority of records. Sort of. The join is still necessary for the query, because we still need the other content items. But there would be no results from the other joined tables most of the time, and I expect the query planner to handle that efficiently.

--- a/docs/decisions/07-posts-data-model.md
+++ b/docs/decisions/07-posts-data-model.md
@@ -61,7 +61,7 @@ erDiagram
     
 ```
 
-So, everything becomes a post, with some child content items. It doesn't currently happen (much?) in the wild, but this would allow us to easily handle activities that include multiple content-like objects (multiple notes, images, questions, mix-and-match, etc). One other benefit this has is that it makes it easier to assign meaningful IDs to our `Activities`. This is because the post, as a container for its content, will tend to map very easily onto the activity that carried it. The types above are mostly illustrative, not complete or final. The idea is that they would implement an interface, call it `IContent`, which would provide enough information to build a feed of posts. That would 
+So, everything becomes a post, with some child content items. It doesn't currently happen (much?) in the wild, but this would allow us to easily handle activities that include multiple content-like objects (multiple notes, images, questions, mix-and-match, etc). The types above are mostly illustrative, not complete or final. The idea is that they would implement an interface, call it `IContent`, which would provide enough information to build a feed of posts. That would make it a lot easier to actually provide those feeds to clients. Without *something* like that, clients would have had to make at least one follow-up request to get the actual content of feed items that were otherwise only a list of IDs/URLs.
 
 ```mermaid
 classDiagram

--- a/docs/decisions/07-posts-data-model.md
+++ b/docs/decisions/07-posts-data-model.md
@@ -4,7 +4,7 @@ We can expect almost any of the ActivityStreams Object types to federate in a wa
 
 ## Status
 
-- [ ] Decided 
+- [x] Decided (2024-01-02)
 - [ ] Decided Against 
 - [ ] Deferred 
 - [ ] Superseded 
@@ -158,3 +158,8 @@ Do we need `IContent`, or is the base/abstract `Content` class enough?
 
 ### AS inReplyTo
 AP/AS have some types that are pretty obviously content: `Note`, `Image`, `Document`, `Video`, `Audio`, `Article`, `Page`, `Event`, `Question`. It's not hard to figure out what it means for something to be `inReplyTo` one of those types. But, `Object` is the base type for everything in ActivityStreams, and the spec permits any object to be `inReplyTo` any other object. What does it mean if a `Note` is in reply to a `Collection`, or a `Profile`, or an `Update`? I don't know, and neither do the spec authors. So, we're just not dealing with that. If we ever start receiving federated documents doing that, then we can decide how to handle it. And honestly that might mean we just choose to discard those activities for being incomprehensible to our data model. It seems like that would have to be either a very different app than ours, or just a nonsensical implementation.
+
+### Quotes?
+How does this design model quote posts?
+
+There are a couple of options. We can experiment when we get to that point, but the one that seems most likely is if `Post` also implements `IContent`, and then other posts can simply be part of the contents collection. [See the PR for some discussion](https://github.com/Letterbook/Letterbook/pull/144).


### PR DESCRIPTION
Proposes a change to the content data model, which should make both inbound activity processing and general maintenance easier. It's an ADR, so the ADR doc itself is really the best description.
https://github.com/Letterbook/Letterbook/compare/adr/post-data-model?expand=1&short_path=50f4b27#diff-50f4b271e491af84f4eaadb6740d8ca218ff6a810c2441bab15fb76eab205958

## Details
- Introduce the concept of a post
- Concepts like Notes and Images then become content within a post

## Related
- #139 
- #126
