### PR TITLE
Reducing allocations in ShortId generation and parsing

### DIFF
--- a/Letterbook.Core.Tests/ShortIdTests.cs
+++ b/Letterbook.Core.Tests/ShortIdTests.cs
@@ -5,8 +5,16 @@ namespace Letterbook.Core.Tests;
 
 public class ShortIdTests
 {
-    public static IEnumerable<object[]> GuidList(int count) =>
-        Enumerable.Range(0, count).Select(_ => new object[] { Guid.NewGuid() });
+    public static TheoryData<Guid> GuidList(int count)
+    {
+        var data = new TheoryData<Guid>();
+        for (var i = 0; i < count; i++)
+        {
+            data.Add(Guid.NewGuid());
+        }
+
+        return data;
+    }
 
     [Theory]
     [MemberData(nameof(GuidList), 10)]

--- a/Letterbook.Core/Extensions/ShortId.cs
+++ b/Letterbook.Core/Extensions/ShortId.cs
@@ -6,14 +6,46 @@ public static class ShortId
 {
     public static string ToShortId(this Guid g)
     {
-        var id = Convert.ToBase64String(g.ToByteArray());
-        return id.Replace("=", "").Replace("+", "-").Replace("/", "_");
+        Span<byte> guidBytes = stackalloc byte[16];
+        if (!g.TryWriteBytes(guidBytes))
+        {
+            // this should never happen
+            throw new InvalidOperationException("Could not write Guid bytes");
+        }
+
+        Span<char> base64 = stackalloc char[24];
+        if (!Convert.TryToBase64Chars(guidBytes, base64, out int _))
+        {
+            // this should never happen
+            throw new InvalidOperationException("Could not convert to base64");
+        }
+
+        base64.Replace('+', '-');
+        base64.Replace('/', '_');
+
+        return new string(base64.TrimEnd('='));
     }
 
-    public static Guid ToGuid(string shortId)
+    public static Guid ToGuid(ReadOnlySpan<char> shortId)
     {
-        var id = shortId.Replace("-", "+").Replace("_", "/").PadRight(24, '=');
-        return new Guid(Convert.FromBase64String(id));
+        if (shortId.Length != 22)
+        {
+            throw new ArgumentException("Invalid shortId", nameof(shortId));
+        }
+
+        Span<char> id = stackalloc char[24];
+        shortId.CopyTo(id);
+        id.Replace('-', '+');
+        id.Replace('_', '/');
+        id[^2..].Fill('=');
+
+        Span<byte> guidBytes = stackalloc byte[16];
+        if (!Convert.TryFromBase64Chars(id, guidBytes, out int _))
+        {
+            throw new ArgumentException("Invalid shortId", nameof(shortId));
+        }
+
+        return new Guid(guidBytes);
     }
 
     public static string NewShortId()


### PR DESCRIPTION
  What is the purpose of this PR? What does it do, and how?

Reduces heap allocations when generating and parsing ShortId values by using stack-allocated spans instead of strings and byte arrays.

## Related

#150 
