### PR TITLE
provide additional context for first-dev-run documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,8 @@ dotnet --version
 
 #### Using the `dotnet` CLI
 
+Before continuing to run the project, you'll need to setup [Dependencies][#Dependencies].
+
 ```shell
 dotnet watch run --project Letterbook.Api
 ```
@@ -127,6 +129,8 @@ To run these dependencies, simply do
 ```shell
 docker-compose up
 ```
+
+Note that if you already have Postgres running locally on its default port, docker cannot override the default port and provide its postgresql instance instead. You'll need to either shutdown your local postgres instance or change the port mappings in `docker-compose.yml` and `/Letterbook.Api/appsettings.Development.json`.
 
 ### Database
 

--- a/Letterbook.Adapter.Db/readme.md
+++ b/Letterbook.Adapter.Db/readme.md
@@ -8,6 +8,8 @@ dotnet tool install --global dotnet-ef
 
 # Migrations
 
+You should either run these commands from this subdirectory or add the `--project Letterbook.Adapter.DB` flag.
+
 To generate a new migration:
 ```shell
 dotnet ef migrations add NAME


### PR DESCRIPTION
  What is the purpose of this PR? What does it do, and how?

## Details
- some additions to the documentation which I believe will help the "I've cloned it and want to run it locally" first-time dev experience. 

## Related

