### PR TITLE
Fix insert/update on Profiles

### DIFF
--- a/Letterbook.Adapter.Db/Letterbook.Adapter.Db.csproj
+++ b/Letterbook.Adapter.Db/Letterbook.Adapter.Db.csproj
@@ -18,16 +18,17 @@
       </PackageReference>
       <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.10" />
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.8.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.10" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.5">
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
       <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.7.0" />
     </ItemGroup>
 

--- a/Letterbook.Adapter.Db/Migrations/20240107192358_UpdateFrameworkV8.Designer.cs
+++ b/Letterbook.Adapter.Db/Migrations/20240107192358_UpdateFrameworkV8.Designer.cs
@@ -4,6 +4,7 @@ using Letterbook.Adapter.Db;
 using Letterbook.Core.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Letterbook.Adapter.Db.Migrations
 {
     [DbContext(typeof(RelationalContext))]
-    partial class RelationalContextModelSnapshot : ModelSnapshot
+    [Migration("20240107192358_UpdateFrameworkV8")]
+    partial class UpdateFrameworkV8
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Letterbook.Adapter.Db/Migrations/20240107192358_UpdateFrameworkV8.cs
+++ b/Letterbook.Adapter.Db/Migrations/20240107192358_UpdateFrameworkV8.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Letterbook.Adapter.Db.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateFrameworkV8 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/Letterbook.Adapter.Db/RelationalContext.cs
+++ b/Letterbook.Adapter.Db/RelationalContext.cs
@@ -4,6 +4,8 @@ using Letterbook.Core.Models;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
+using Npgsql;
+
 #pragma warning disable CS8618
 // EntityFramework does the right thing
 
@@ -40,7 +42,9 @@ public class RelationalContext : DbContext
 
     protected override void OnConfiguring(DbContextOptionsBuilder options)
     {
-        options.UseNpgsql(_config.GetConnectionString());
+        var builder = new NpgsqlDataSourceBuilder(_config.GetConnectionString());
+        builder.EnableDynamicJson();
+        options.UseNpgsql(builder.Build());
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)


### PR DESCRIPTION
Npgsql added an explicit opt-in to dynamic json serialization for json/jsonb columns in dotnet 8. So, we have to opt-in. And get on a consistent version of Npgsql throughout the solution, while we're at it.

## Details
- Just what it says on the tin

## Related
- Fixes the startup crash reported by @mattly (TY!)

For the curious, it's likely I didn't notice that crash before now because the only real time we try to create profiles with custom fields at the moment is when seeding the db with a default admin account. Which I haven't needed to do recently.