### PR TITLE
AST to Post mappers

### DIFF
--- a/Letterbook.Adapter.ActivityPub.Test/ExtensionTests.cs
+++ b/Letterbook.Adapter.ActivityPub.Test/ExtensionTests.cs
@@ -1,0 +1,82 @@
+﻿using ActivityPub.Types.AS;
+using ActivityPub.Types.Util;
+
+namespace Letterbook.Adapter.ActivityPub.Test;
+
+public class ExtensionTests
+{
+    [Fact(DisplayName = "Should get the linkable object ID")]
+    public void ShouldGetId()
+    {
+        var expected = "https://example.com";
+        var ext = new Linkable<ASObject>(new ASObject() { Id = expected });
+        
+        Assert.True(ext.TryGetId(out var id));
+        Assert.Equal(expected, id.OriginalString);
+    }
+    
+    [Fact(DisplayName = "Should return false when no id")]
+    public void ShouldNotGetId()
+    {
+        var ext = new Linkable<ASObject>(new ASObject());
+        
+        Assert.False(ext.TryGetId(out _));
+    }
+    
+    [Fact(DisplayName = "Should get the object ID")]
+    public void ShouldGetObjectId()
+    {
+        var expected = "https://example.com";
+        var ext = new ASObject() { Id = expected };
+        
+        Assert.True(ext.TryGetId(out var id));
+        Assert.Equal(expected, id.OriginalString);
+    }
+    
+    [Fact(DisplayName = "Should get the href")]
+    public void ShouldGetLink()
+    {
+        var expected = "https://example.com";
+        var ext = new Linkable<ASObject>(new ASLink() { HRef = expected });
+        
+        Assert.True(ext.TryGetId(out var id));
+        Assert.Equal(expected, id.OriginalString);
+    }
+    
+    [Fact(DisplayName = "Should throw ArgumentOutOfRange when there's no non-null")]
+    public void ShouldThrowOutOfRange()
+    {
+        string? s = null;
+        Assert.Throws<ArgumentOutOfRangeException>(() => Extensions.NotNull(s));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Extensions.NotNull());
+    }
+    
+    [Fact(DisplayName = "Should return the first non-null value")]
+    public void ShouldGetNonNull()
+    {
+        var s = "right";
+        Assert.Equal(s, Extensions.NotNull(s));
+        Assert.Equal(s, Extensions.NotNull(null, s));
+        Assert.Equal(s, Extensions.NotNull(null, s, null));
+        Assert.Equal(s, Extensions.NotNull(null, s, null, "other"));
+        Assert.Equal(s, Extensions.NotNull(s, "wrong", null, "other"));
+    }
+
+    [Fact(DisplayName = "Should get IDs from a list of ASObject")]
+    public void ShouldGetObjectListIds()
+    {
+        var list = new[] { new ASObject() { Id = "https://test.example" }, new ASObject() { Id = "https://test.example/2"} };
+        var actual = list.SelectIds();
+        
+        Assert.Equal(2, actual.Count());
+    }
+    
+    [Fact(DisplayName = "Should get IDs from a list of ASLink")]
+    public void ShouldGetLinkListIds()
+    {
+        var list = new[] { new ASLink() { HRef = "https://test.example" }, new ASLink() { HRef = "https://test.example/2"} };
+        var actual = list.SelectIds();
+        
+        Assert.Equal(2, actual.Count());
+    }
+}

--- a/Letterbook.Adapter.ActivityPub.Test/MapperTests.cs
+++ b/Letterbook.Adapter.ActivityPub.Test/MapperTests.cs
@@ -153,5 +153,13 @@ public class MapperTests : IClassFixture<JsonLdSerializerFixture>
 
             Assert.NotNull(mapped);
         }
+
+        [Fact]
+        public void NoItDoesnt()
+        {
+            string? s = null;
+            Assert.Throws<ArgumentOutOfRangeException>(() => Extensions.NotNull(s));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Extensions.NotNull());
+        }
     }
 }

--- a/Letterbook.Adapter.ActivityPub.Test/MapperTests.cs
+++ b/Letterbook.Adapter.ActivityPub.Test/MapperTests.cs
@@ -7,6 +7,7 @@ using AutoMapper;
 using Letterbook.Adapter.ActivityPub.Types;
 using Letterbook.Core.Tests.Fakes;
 using Letterbook.Core.Tests.Fixtures;
+using Medo;
 using Xunit.Abstractions;
 
 namespace Letterbook.Adapter.ActivityPub.Test;
@@ -149,9 +150,13 @@ public class MapperTests : IClassFixture<JsonLdSerializerFixture>
         [Fact]
         public void CanMapSimpleNote()
         {
-            var mapped = AstMapper.Map<Models.Post>(_simpleNote);
+            var actual = AstMapper.Map<Models.Post>(_simpleNote);
 
-            Assert.NotNull(mapped);
+            Assert.NotEqual(actual.Id, Uuid7.Empty);
+            Assert.Single(actual.Contents);
+            Assert.All(actual.Contents, content => Assert.Equal(actual.Id, content.Post.Id));
+            Assert.Equal(actual.Id, actual.Contents.First().Post.Id);
+            Assert.Equal(actual.ContentRootIdUri, actual.Contents.First().FediId);
         }
 
         [Fact]

--- a/Letterbook.Adapter.ActivityPub.Test/MapperTests.cs
+++ b/Letterbook.Adapter.ActivityPub.Test/MapperTests.cs
@@ -1,8 +1,10 @@
 using System.Reflection;
 using ActivityPub.Types.AS;
+using ActivityPub.Types.AS.Collection;
 using ActivityPub.Types.AS.Extended.Actor;
 using ActivityPub.Types.AS.Extended.Object;
 using ActivityPub.Types.Conversion;
+using ActivityPub.Types.Util;
 using AutoMapper;
 using Letterbook.Adapter.ActivityPub.Types;
 using Letterbook.Core.Tests.Fakes;
@@ -158,13 +160,35 @@ public class MapperTests : IClassFixture<JsonLdSerializerFixture>
             Assert.Equal(actual.Id, actual.Contents.First().Post.Id);
             Assert.Equal(actual.ContentRootIdUri, actual.Contents.First().FediId);
         }
-
+        
         [Fact]
-        public void NoItDoesnt()
+        public void CanMapThreadFromContext()
         {
-            string? s = null;
-            Assert.Throws<ArgumentOutOfRangeException>(() => Extensions.NotNull(s));
-            Assert.Throws<ArgumentOutOfRangeException>(() => Extensions.NotNull());
+            var expected = "https://note.example/note/1/thread/";
+            _simpleNote.Context = new Linkable<ASObject>(new ASLink() { HRef = expected });
+            var actual = AstMapper.Map<Models.Post>(_simpleNote);
+
+            Assert.Equal(expected, actual.Thread.FediId.ToString());
+        }
+        
+        [Fact]
+        public void CanMapThreadFromReplies()
+        {
+            var expected = "https://note.example/note/1/thread/";
+            _simpleNote.Replies = new ASCollection { Id = expected };
+            var actual = AstMapper.Map<Models.Post>(_simpleNote);
+
+            Assert.Equal(expected, actual.Thread.FediId.ToString());
+        }
+        [Fact]
+        public void CanMapThreadPreferContext()
+        {
+            var expected = "https://note.example/note/1/thread/";
+            _simpleNote.Replies = new ASCollection { Id = expected };
+            _simpleNote.Context = new Linkable<ASObject>(new ASLink() { HRef = "https://note.example/note/3" });
+            var actual = AstMapper.Map<Models.Post>(_simpleNote);
+
+            Assert.Equal(expected, actual.Thread.FediId.ToString());
         }
     }
 }

--- a/Letterbook.Adapter.ActivityPub.Test/MapperTests.cs
+++ b/Letterbook.Adapter.ActivityPub.Test/MapperTests.cs
@@ -17,103 +17,141 @@ namespace Letterbook.Adapter.ActivityPub.Test;
 /// </summary>
 public class MapperTests : IClassFixture<JsonLdSerializerFixture>
 {
-    private readonly ITestOutputHelper _output;
-    private static IMapper AstMapper => new Mapper(Mappers.AstMapper.Default);
-#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
-    private IMapper _modelMapper;
-#pragma warning restore CS0649 // Field is never assigned to, and will always have its default value
-    private FakeProfile _fakeProfile;
-    private Models.Profile _profile;
-    private readonly IJsonLdSerializer _serializer;
-
     private static string DataDir => Path.Join(
         Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Data");
 
-
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-    public MapperTests(ITestOutputHelper output, JsonLdSerializerFixture serializerFixture)
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+    public class MapFromModelTests : IClassFixture<JsonLdSerializerFixture>
     {
-        _output = output;
-        _serializer = serializerFixture.JsonLdSerializer;
+        private readonly ITestOutputHelper _output;
 
-        _output.WriteLine($"Bogus Seed: {Init.WithSeed()}");
-        _fakeProfile = new FakeProfile("letterbook.example");
-        _profile = _fakeProfile.Generate();
+        private FakeProfile _fakeProfile;
+        private Models.Profile _profile;
+        private readonly IJsonLdSerializer _serializer;
+#pragma warning disable CS8618
+#pragma warning disable CS0649
+        private static IMapper ModelMapper;
+#pragma warning restore CS0649
+#pragma warning restore CS8618
+
+        public MapFromModelTests(ITestOutputHelper output, JsonLdSerializerFixture serializerFixture)
+        {
+            _output = output;
+            _serializer = serializerFixture.JsonLdSerializer;
+
+            _output.WriteLine($"Bogus Seed: {Init.WithSeed()}");
+            _fakeProfile = new FakeProfile("letterbook.example");
+            _profile = _fakeProfile.Generate();
+        }
+
+        [Fact(Skip = "Need ModelMapper")]
+        public void MapProfileDefault()
+        {
+            var actual = ModelMapper.Map<PersonActorExtension>(_profile);
+
+            Assert.Equal(_profile.Id.ToString(), actual.Id);
+            Assert.Equal(_profile.Inbox.ToString(), actual.Inbox.Id);
+            Assert.Equal(_profile.Outbox.ToString(), actual.Outbox.Id);
+            Assert.Equal(_profile.Following.ToString(), actual.Following?.Id);
+            Assert.Equal(_profile.Followers.ToString(), actual.Followers?.Id);
+        }
+
+        [Fact(Skip = "Need ModelMapper")]
+        public void CanMapProfileDefaultSigningKey()
+        {
+            var expected = _profile.Keys.First().GetRsa().ExportSubjectPublicKeyInfoPem();
+
+            var actual = ModelMapper.Map<PersonActorExtension>(_profile);
+
+            Assert.Equal(actual?.PublicKey?.PublicKeyPem, expected);
+            Assert.Equal(actual?.PublicKey?.Owner?.Value?.Id, _profile.Id.ToString());
+            Assert.Equal(actual?.PublicKey?.Id, _profile.Keys.First().Id.ToString());
+        }
+
+        [Fact(Skip = "Need ModelMapper")]
+        public void CanMapActorCore()
+        {
+            var actual = ModelMapper.Map<PersonActorExtension>(_profile);
+
+            Assert.Equal(_profile.Id.ToString(), actual.Id);
+            Assert.Equal(_profile.Inbox.ToString(), actual.Inbox.HRef);
+            Assert.Equal(_profile.Outbox.ToString(), actual.Outbox.HRef);
+            Assert.Equal(_profile.Following.ToString(), actual.Following?.HRef!);
+            Assert.Equal(_profile.Followers.ToString(), actual.Followers?.HRef!);
+            Assert.Equal(_profile.Handle, actual.PreferredUsername?.DefaultValue);
+            Assert.Equal(_profile.DisplayName, actual.Name?.DefaultValue);
+        }
+
+        [Fact(Skip = "Need ModelMapper")]
+        public void CanMapActorExtensionsPublicKey()
+        {
+            var expectedKey = _profile.Keys.First();
+            var expectedPem = expectedKey.GetRsa().ExportSubjectPublicKeyInfoPem();
+            var actual = ModelMapper.Map<PersonActorExtension>(_profile);
+
+            Assert.Equal(expectedPem, actual.PublicKey?.PublicKeyPem);
+            Assert.Equal(expectedKey.Id.ToString(), actual.PublicKey?.Id);
+        }
     }
 
-    [Fact]
-    public void ValidConfig()
+    public class MapFromAstTests : IClassFixture<JsonLdSerializerFixture>
     {
-        Mappers.AstMapper.Default.AssertConfigurationIsValid();
-    }
+        private readonly ITestOutputHelper _output;
+        private static IMapper AstMapper => new Mapper(Mappers.AstMapper.Default);
+        private readonly IJsonLdSerializer _serializer;
+        private NoteObject _simpleNote;
 
-    [Fact]
-    public void CanMapLetterbookActor()
-    {
-        using var fs = new FileStream(Path.Join(DataDir, "LetterbookActor.json"), FileMode.Open);
-        var actor = _serializer.Deserialize<PersonActorExtension>(fs)!;
-        var mapped = AstMapper.Map<Models.Profile>(actor);
-        
-        Assert.NotNull(mapped);
-    }
-    
-    [Fact(Skip = "broken")]
-    public void CanMapMastodonActor()
-    {
-        using var fs = new FileStream(Path.Join(DataDir, "Actor.json"), FileMode.Open);
-        var actor = _serializer.Deserialize<PersonActorExtension>(fs)!;
-        var mapped = AstMapper.Map<Models.Profile>(actor);
-        
-        Assert.NotNull(mapped);
-    }
+        public MapFromAstTests(ITestOutputHelper output, JsonLdSerializerFixture serializerFixture)
+        {
+            _output = output;
+            _serializer = serializerFixture.JsonLdSerializer;
 
-    [Fact(Skip = "Need ModelMapper")]
-    public void MapProfileDefault()
-    {
-        var actual = _modelMapper.Map<PersonActorExtension>(_profile);
+            _output.WriteLine($"Bogus Seed: {Init.WithSeed()}");
+            
+            _simpleNote = new NoteObject
+            {
+                Id = "https://note.example/note/1",
+                Content = "<p>test content</p>",
+                Source = new ASObject
+                {
+                    Content = "test content",
+                    MediaType = "text"
+                }
+            };
+            _simpleNote.AttributedTo.Add("https://note.example/actor/1");
+        }
 
-        Assert.Equal(_profile.Id.ToString(), actual.Id);
-        Assert.Equal(_profile.Inbox.ToString(), actual.Inbox.Id);
-        Assert.Equal(_profile.Outbox.ToString(), actual.Outbox.Id);
-        Assert.Equal(_profile.Following.ToString(), actual.Following?.Id);
-        Assert.Equal(_profile.Followers.ToString(), actual.Followers?.Id);
-    }
+        [Fact]
+        public void ValidConfig()
+        {
+            Mappers.AstMapper.Default.AssertConfigurationIsValid();
+        }
 
-    [Fact(Skip = "Need ModelMapper")]
-    public void CanMapProfileDefaultSigningKey()
-    {
-        var expected = _profile.Keys.First().GetRsa().ExportSubjectPublicKeyInfoPem();
+        [Fact]
+        public void CanMapLetterbookActor()
+        {
+            using var fs = new FileStream(Path.Join(DataDir, "LetterbookActor.json"), FileMode.Open);
+            var actor = _serializer.Deserialize<PersonActorExtension>(fs)!;
+            var mapped = AstMapper.Map<Models.Profile>(actor);
 
-        var actual = _modelMapper.Map<PersonActorExtension>(_profile);
+            Assert.NotNull(mapped);
+        }
 
-        Assert.Equal(actual?.PublicKey?.PublicKeyPem, expected);
-        Assert.Equal(actual?.PublicKey?.Owner?.Value?.Id, _profile.Id.ToString());
-        Assert.Equal(actual?.PublicKey?.Id, _profile.Keys.First().Id.ToString());
-    }
-    
-    [Fact(Skip = "Need ModelMapper")]
-    public void CanMapActorCore()
-    {
-        var actual = _modelMapper.Map<PersonActorExtension>(_profile);
+        [Fact]
+        public void CanMapMastodonActor()
+        {
+            using var fs = new FileStream(Path.Join(DataDir, "Actor.json"), FileMode.Open);
+            var actor = _serializer.Deserialize<PersonActorExtension>(fs)!;
+            var mapped = AstMapper.Map<Models.Profile>(actor);
 
-        Assert.Equal(_profile.Id.ToString(), actual.Id);
-        Assert.Equal(_profile.Inbox.ToString(), actual.Inbox.HRef);
-        Assert.Equal(_profile.Outbox.ToString(), actual.Outbox.HRef);
-        Assert.Equal(_profile.Following.ToString(), actual.Following?.HRef!);
-        Assert.Equal(_profile.Followers.ToString(), actual.Followers?.HRef!);
-        Assert.Equal(_profile.Handle, actual.PreferredUsername?.DefaultValue);
-        Assert.Equal(_profile.DisplayName, actual.Name?.DefaultValue);
-    }
+            Assert.NotNull(mapped);
+        }
 
-    [Fact(Skip = "Need ModelMapper")]
-    public void CanMapActorExtensionsPublicKey()
-    {
-        var expectedKey = _profile.Keys.First();
-        var expectedPem = expectedKey.GetRsa().ExportSubjectPublicKeyInfoPem();
-        var actual = _modelMapper.Map<PersonActorExtension>(_profile);
+        [Fact]
+        public void CanMapSimpleNote()
+        {
+            var mapped = AstMapper.Map<Models.Post>(_simpleNote);
 
-        Assert.Equal(expectedPem, actual.PublicKey?.PublicKeyPem);
-        Assert.Equal(expectedKey.Id.ToString(), actual.PublicKey?.Id);
+            Assert.NotNull(mapped);
+        }
     }
 }

--- a/Letterbook.Adapter.ActivityPub/Extensions.cs
+++ b/Letterbook.Adapter.ActivityPub/Extensions.cs
@@ -7,6 +7,8 @@ namespace Letterbook.Adapter.ActivityPub;
 
 public static class Extensions
 {
+    private static readonly Func<object?, bool> TestNotNull = x => x is not null;
+    
     public static bool TryGetId(this Linkable<ASObject> linkable, [NotNullWhen(true)]out Uri? id)
     {
         if (linkable.TryGetValue(out var value) && value.Id != null)
@@ -56,30 +58,18 @@ public static class Extensions
         return false;
     }
 
-    public static bool TryGetId(this ASType asType, [NotNullWhen(true)] out Uri? id)
-    {
-        if (asType.Id != null)
-        {
-            id = new Uri(asType.Id);
-            return true;
-        }
+    public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source) where T : class =>
+        source.Where((Func<T?, bool>)TestNotNull)!;
 
-        if (asType.Is<ASLink>(out var link))
-        {
-            id = link.HRef;
-            return true;
-        }
-
-        id = default;
-        return false;
-    }
+    public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> source) where T : struct =>
+        source.Where(x => x.HasValue).Select(x => x!.Value);
 
     public static string NotNull(params string?[] args) =>
-        args.FirstOrDefault(s => s is not null)
+        args.FirstOrDefault(s => TestNotNull(s))
         ?? throw new ArgumentOutOfRangeException(nameof(args), "All of the attempted values were null");
 
     public static IEnumerable<Uri> SelectIds(this IEnumerable<ASObject> objects) =>
-        objects.Select(o => o.Id).OfType<string>().Select(s => new Uri(s));
+        objects.Select(o => o.Id).WhereNotNull().Select(s => new Uri(s));
 
     public static IEnumerable<Uri> SelectIds(this IEnumerable<ASLink> links) =>
         links.Select(o => o.HRef.Uri);

--- a/Letterbook.Adapter.ActivityPub/Extensions.cs
+++ b/Letterbook.Adapter.ActivityPub/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using ActivityPub.Types.AS;
+using ActivityPub.Types.AS.Collection;
 using ActivityPub.Types.Util;
 
 namespace Letterbook.Adapter.ActivityPub;
@@ -23,6 +24,25 @@ public static class Extensions
         id = null;
         return false;
     }
+
+    public static bool TryGetId(this Linkable<ASCollection> linkable, [NotNullWhen(true)] out Uri? id)
+    {
+        if (linkable.TryGetValue(out var value) && value.Id != null)
+        {
+            id = new Uri(value.Id);
+            return true;
+        }
+        
+        if (linkable.TryGetLink(out var link))
+        {
+            id = link.HRef;
+            return true;
+        }
+
+        id = null;
+        return false;
+    }
+
     
     public static bool TryGetId(this ASObject aso, [NotNullWhen(true)]out Uri? id)
     {

--- a/Letterbook.Adapter.ActivityPub/Extensions.cs
+++ b/Letterbook.Adapter.ActivityPub/Extensions.cs
@@ -53,4 +53,14 @@ public static class Extensions
         id = default;
         return false;
     }
+
+    public static string NotNull(params string?[] args) =>
+        args.FirstOrDefault(s => s is not null)
+        ?? throw new ArgumentOutOfRangeException(nameof(args), "All of the attempted values were null");
+
+    public static IEnumerable<Uri> SelectIds(this IEnumerable<ASObject> objects) =>
+        objects.Select(o => o.Id).OfType<string>().Select(s => new Uri(s));
+
+    public static IEnumerable<Uri> SelectIds(this IEnumerable<ASLink> links) =>
+        links.Select(o => o.HRef.Uri);
 }

--- a/Letterbook.Adapter.ActivityPub/Letterbook.Adapter.ActivityPub.csproj
+++ b/Letterbook.Adapter.ActivityPub/Letterbook.Adapter.ActivityPub.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-      <PackageReference Include="ActivityPub.Types" Version="0.1.0-snapshot.2023-12-29.15-35-53" />
+      <PackageReference Include="ActivityPub.Types" Version="0.1.0-snapshot.2024-01-08.18-02-38" />
       <PackageReference Include="AutoMapper" Version="12.0.1" />
       <PackageReference Include="AutoMapper.Collection" Version="9.0.0" />
       <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" />

--- a/Letterbook.Adapter.Db/EntityConfigs/ConfigureContent.cs
+++ b/Letterbook.Adapter.Db/EntityConfigs/ConfigureContent.cs
@@ -9,6 +9,6 @@ public class ConfigureContent : IEntityTypeConfiguration<Models.Content>
     {
         builder.HasDiscriminator();
         builder.HasKey(note => note.Id);
-        builder.HasIndex(note => note.IdUri);
+        builder.HasIndex(note => note.FediId);
     }
 }

--- a/Letterbook.Adapter.Db/EntityConfigs/ConfigurePost.cs
+++ b/Letterbook.Adapter.Db/EntityConfigs/ConfigurePost.cs
@@ -7,8 +7,8 @@ public class ConfigurePost : IEntityTypeConfiguration<Models.Post>
 {
     public void Configure(EntityTypeBuilder<Models.Post> builder)
     {
-        builder.HasIndex(post => post.IdUri);
-        builder.HasIndex(post => post.ContentRootId);
+        builder.HasIndex(post => post.FediId);
+        builder.HasIndex(post => post.ContentRootIdUri);
 
         builder.HasMany<Models.Content>(post => post.Contents)
             .WithOne(content => content.Post);

--- a/Letterbook.Adapter.Db/EntityConfigs/ConfigureThreadContext.cs
+++ b/Letterbook.Adapter.Db/EntityConfigs/ConfigureThreadContext.cs
@@ -7,10 +7,12 @@ public class ConfigureThreadContext : IEntityTypeConfiguration<Models.ThreadCont
 {
     public void Configure(EntityTypeBuilder<Models.ThreadContext> builder)
     {
-        builder.HasIndex(conversation => conversation.IdUri);
+        builder.HasIndex(conversation => conversation.FediId);
 
         builder.HasOne<Models.Post>(conversation => conversation.Root);
         builder.HasMany<Models.Post>(conversation => conversation.Posts)
             .WithOne(post => post.Thread);
+
+        builder.Ignore(thread => thread.Heuristics);
     }
 }

--- a/Letterbook.Adapter.Db/Migrations/20240112053915_FixPostProperties.Designer.cs
+++ b/Letterbook.Adapter.Db/Migrations/20240112053915_FixPostProperties.Designer.cs
@@ -4,6 +4,7 @@ using Letterbook.Adapter.Db;
 using Letterbook.Core.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Letterbook.Adapter.Db.Migrations
 {
     [DbContext(typeof(RelationalContext))]
-    partial class RelationalContextModelSnapshot : ModelSnapshot
+    [Migration("20240112053915_FixPostProperties")]
+    partial class FixPostProperties
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Letterbook.Adapter.Db/Migrations/20240112053915_FixPostProperties.cs
+++ b/Letterbook.Adapter.Db/Migrations/20240112053915_FixPostProperties.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Letterbook.Adapter.Db.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixPostProperties : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Audience_Profiles_SourceId",
+                table: "Audience");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Post_ContentRootId",
+                table: "Post");
+
+            migrationBuilder.DropColumn(
+                name: "ContentRootId",
+                table: "Post");
+
+            migrationBuilder.RenameColumn(
+                name: "IdUri",
+                table: "ThreadContext",
+                newName: "FediId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_ThreadContext_IdUri",
+                table: "ThreadContext",
+                newName: "IX_ThreadContext_FediId");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ContentRootIdUri",
+                table: "Post",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SourceId",
+                table: "Audience",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Post_ContentRootIdUri",
+                table: "Post",
+                column: "ContentRootIdUri");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Audience_Profiles_SourceId",
+                table: "Audience",
+                column: "SourceId",
+                principalTable: "Profiles",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Audience_Profiles_SourceId",
+                table: "Audience");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Post_ContentRootIdUri",
+                table: "Post");
+
+            migrationBuilder.DropColumn(
+                name: "ContentRootIdUri",
+                table: "Post");
+
+            migrationBuilder.RenameColumn(
+                name: "FediId",
+                table: "ThreadContext",
+                newName: "IdUri");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_ThreadContext_FediId",
+                table: "ThreadContext",
+                newName: "IX_ThreadContext_IdUri");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ContentRootId",
+                table: "Post",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "SourceId",
+                table: "Audience",
+                type: "text",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Post_ContentRootId",
+                table: "Post",
+                column: "ContentRootId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Audience_Profiles_SourceId",
+                table: "Audience",
+                column: "SourceId",
+                principalTable: "Profiles",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/Letterbook.Api/Letterbook.Api.csproj
+++ b/Letterbook.Api/Letterbook.Api.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ActivityPub.Types" Version="0.1.0-snapshot.2023-12-29.15-35-53" />
+    <PackageReference Include="ActivityPub.Types" Version="0.1.0-snapshot.2024-01-08.18-02-38" />
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Collection" Version="9.0.0" />
     <PackageReference Include="DarkLink.Web.WebFinger.Server" Version="1.0.0" />

--- a/Letterbook.Core/Letterbook.Core.csproj
+++ b/Letterbook.Core/Letterbook.Core.csproj
@@ -24,7 +24,7 @@
       <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-      <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.0.3" />
+      <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.2.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 

--- a/Letterbook.Core/Models/Audience.cs
+++ b/Letterbook.Core/Models/Audience.cs
@@ -14,11 +14,10 @@ public class Audience : IEquatable<Audience>, IObjectRef
     private Audience()
     {
         Id = default!;
-        Source = default!;
     }
     
     public Uri Id { get; set; }
-    public Profile Source { get; set; }
+    public Profile? Source { get; set; }
     // LocalId isn't a meaningful concept for Audience, but it's required by IObjectRef
     public Guid? LocalId { get; set; }
     public string Authority => Id.Authority;
@@ -30,7 +29,7 @@ public class Audience : IEquatable<Audience>, IObjectRef
     /// public objects. So Letterbook infers the followers audience in this case.
     /// </summary>
     public static Audience Public => _public;
-    public static Audience FromUri(Uri id, Profile source) => new () { Id = id, Source = source};
+    public static Audience FromUri(Uri id, Profile? source = null) => new () { Id = id, Source = source};
     public static Audience Followers(Profile creator) => FromUri(creator.Followers, creator);
 
     public static Audience Subscribers(Profile creator)

--- a/Letterbook.Core/Models/IContent.cs
+++ b/Letterbook.Core/Models/IContent.cs
@@ -5,28 +5,35 @@ namespace Letterbook.Core.Models;
 public interface IContent
 {
     Uuid7 Id { get; set; }
-    Uri IdUri { get; set; }
+    Uri FediId { get; set; }
     Post Post { get; set; }
     string? Summary { get; set; }
     string? Preview { get; set; }
     Uri? Source { get; set; }
     string Type { get; }
+
+    public string? GeneratePreview();
+    public void Sanitize();
 }
 
 public abstract class Content : IContent
 {
     protected Content()
     {
-        Id = Uuid7.NewGuid();
-        IdUri = default!;
+        Id = Uuid7.NewUuid7();
+        FediId = default!;
         Post = default!;
     }
     
-    public required Uuid7 Id { get; set; }
-    public required Uri IdUri { get; set; }
+    public Uuid7 Id { get; set; }
+    public required Uri FediId { get; set; }
     public required Post Post { get; set; }
     public string? Summary { get; set; }
     public string? Preview { get; set; }
     public Uri? Source { get; set; }
     public abstract string Type { get; }
+    
+    public abstract string? GeneratePreview();
+
+    public abstract void Sanitize();
 }

--- a/Letterbook.Core/Models/Mention.cs
+++ b/Letterbook.Core/Models/Mention.cs
@@ -1,8 +1,7 @@
 ﻿namespace Letterbook.Core.Models;
 
 /// <summary>
-/// A Mention is when some kind of object (usually a Note, sometimes an Image, theoretically others) is addressed to 
-/// another individual Actor at any level of visibility.
+/// A Mention is when a Post is addressed to another individual Profile at any level of visibility.
 /// </summary>
 public class Mention : IEquatable<Mention>
 {

--- a/Letterbook.Core/Models/Note.cs
+++ b/Letterbook.Core/Models/Note.cs
@@ -1,6 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-using JetBrains.Annotations;
-
+﻿
 namespace Letterbook.Core.Models;
 
 /// <summary>
@@ -9,18 +7,21 @@ namespace Letterbook.Core.Models;
 /// </summary>
 public class Note : Content
 {
-    public override string Type => "Note";
-
     public required string Content { get; set; }
+    public override string Type => "Note";
     
-    public Note()
-    {}
-
-    public Note(Post post, Uri idUri, string content)
+    public override string? GeneratePreview()
     {
-        IdUri = idUri;
-        Content = content;
-        Post = post;
-        Post.Contents.Add(this);
+        // TODO: implement this in a less naive way
+        // Something like first paragraph or x words/characters
+        // Also, probably a good idea to generate from the source text, not the rendered content
+        // (that means we would need to implement a source text)
+        return Content.Substring(0, 100);
     }
+
+    public override void Sanitize()
+    {
+        throw new NotImplementedException();
+    }
+
 }

--- a/Letterbook.Core/Models/Note.cs
+++ b/Letterbook.Core/Models/Note.cs
@@ -16,7 +16,7 @@ public class Note : Content
         // Something like first paragraph or x words/characters
         // Also, probably a good idea to generate from the source text, not the rendered content
         // (that means we would need to implement a source text)
-        return Content.Substring(0, 100);
+        return Content.Substring(0, Math.Min(Content.Length, 100));
     }
 
     public override void Sanitize()

--- a/Letterbook.Core/Models/Post.cs
+++ b/Letterbook.Core/Models/Post.cs
@@ -1,4 +1,5 @@
-﻿using Letterbook.Core.Exceptions;
+﻿using System.Diagnostics.CodeAnalysis;
+using Letterbook.Core.Exceptions;
 using Medo;
 
 namespace Letterbook.Core.Models;
@@ -12,7 +13,14 @@ public class Post
         FediId = default!;
         Thread = default!;
     }
-    
+
+    [SetsRequiredMembers]
+    public Post(Uri fediId, ThreadContext thread) : this()
+    {
+        FediId = fediId;
+        Thread = thread;
+    }
+
     public Uuid7 Id { get; set; }
     public Uri ContentRootIdUri { get; set; }
     public required Uri FediId { get; set; }

--- a/Letterbook.Core/Models/Post.cs
+++ b/Letterbook.Core/Models/Post.cs
@@ -55,52 +55,10 @@ public class Post
     public Uri? Shares { get; set; }
     public IList<Profile> SharesCollection { get; set; } = new List<Profile>();
 
-    // TODO: Post Factory
-    public static Post Create<T>(Profile creator, T content) where T : Content
-    {
-        throw new NotImplementedException();
-    }
-
-    public static Post Create<T>(Profile creator, Uri id, string? summary = null, string? preview = null,
-        Uri? source = null) where T : Content => Create<T>(new List<Profile> { creator }, id, summary, preview, source);
-
-    public static Post Create<T>(IEnumerable<Profile> creators, Uri id, string? summary = null, string? preview = null,
-        Uri? source = null) where T : Content
-    {
-        var post = new Post
-        {
-            FediId = id,
-            ContentRootIdUri = id,
-        };
-        (post.Creators as HashSet<Profile>)!.UnionWith(creators);
-        post.Contents.Add(NewContent<T>(id, summary, preview, source));
-        return post;
-    }
-
-    public T AddContent<T>(Uri canonicalUri, string? summary = null, string? preview = null, Uri? source = null)
-        where T : Content
-    {
-        var t = NewContent<T>(canonicalUri, summary, preview, source);
-        return AddContent(t);
-    }
-
     public T AddContent<T>(T content) where T : Content
     {
         if (Contents.Count == 0) ContentRootIdUri = content.FediId;
         Contents.Add(content);
         return content;
-    }
-
-    private static T NewContent<T>(Uri canonicalUri, string? summary = null, string? preview = null, Uri? source = null)
-        where T : class, IContent
-    {
-        if (Activator.CreateInstance(typeof(T), true) is not T t) 
-            throw CoreException.InternalError($"Can't create Content type {typeof(T)}");
-        t.FediId = canonicalUri;
-        t.Summary = summary;
-        t.Preview = preview;
-        t.Source = source;
-
-        return t;
     }
 }

--- a/Letterbook.Core/Models/ThreadContext.cs
+++ b/Letterbook.Core/Models/ThreadContext.cs
@@ -5,7 +5,35 @@ namespace Letterbook.Core.Models;
 public class ThreadContext
 {
     public Uuid7 Id { get; set; } = Uuid7.NewUuid7();
-    public required Uri IdUri { get; set; }
+    public required Uri FediId { get; set; }
     public ICollection<Post> Posts { get; set; } = new HashSet<Post>();
     public required Post Root { get; set; }
+    public Heuristics? Heuristics { get; init; }
+}
+
+/// <summary>
+/// Heuristics are indicators from the source ActivityPub message that may help in locating the correct ThreadContext
+/// for an inbound post
+/// </summary>
+public class Heuristics
+{
+    /// <summary>
+    /// The collection indicated by the source `context` property
+    /// </summary>
+    public Uri? Context;
+
+    /// <summary>
+    /// The likely root post of the thread
+    /// </summary>
+    public Uri? Root;
+
+    /// <summary>
+    /// The collection indicated by the source `thread` property
+    /// </summary>
+    public Uri? Target;
+
+    /// <summary>
+    /// The post is likely the root of its own thread, and the context can be used as-is
+    /// </summary>
+    public bool NewThread;
 }


### PR DESCRIPTION
Adds basic mapping configs for ASNote, including many APSharp generics.

## Details
- We're making pretty heavy use of custom type converters and value resolvers. AS types are really complex, so I'm not sure I see a way around that. Hopefully it's not too hard to follow.

## Related
- closes #154
