### PR TITLE
Initial authorization service

### DIFF
--- a/Letterbook.Api/Program.cs
+++ b/Letterbook.Api/Program.cs
@@ -1,8 +1,6 @@
 using System.Net;
 using ActivityPub.Types;
 using ActivityPub.Types.AS;
-using ActivityPub.Types.Conversion;
-using DarkLink.Web.WebFinger.Server;
 using Letterbook.Adapter.ActivityPub;
 using Letterbook.Adapter.Db;
 using Letterbook.Adapter.RxMessageBus;
@@ -10,6 +8,7 @@ using Letterbook.Adapter.TimescaleFeeds;
 using Letterbook.Api.Swagger;
 using Letterbook.Core;
 using Letterbook.Core.Adapters;
+using Letterbook.Core.Authorization;
 using Letterbook.Core.Extensions;
 using Letterbook.Core.Models;
 using Letterbook.Core.Workers;
@@ -119,6 +118,7 @@ public class Program
         builder.Services.AddScoped<IAccountEventService, AccountEventService>();
         builder.Services.AddScoped<IAccountProfileAdapter, AccountProfileAdapter>();
         builder.Services.AddScoped<IActivityMessageService, ActivityMessageService>();
+        builder.Services.AddSingleton<IAuthorizationService, AuthorizationService>();
 
         // Register Workers
         builder.Services.AddScoped<SeedAdminWorker>();

--- a/Letterbook.Core/Authorization/AuthorizationService.cs
+++ b/Letterbook.Core/Authorization/AuthorizationService.cs
@@ -1,0 +1,42 @@
+﻿using System.Security.Claims;
+using Letterbook.Core.Models;
+
+namespace Letterbook.Core.Authorization;
+
+public class AuthorizationService : IAuthorizationService
+{
+    public Decision Create<T>(IEnumerable<Claim> claims, T target) where T : IFederated
+    {
+        return Decision.Allow("todo", claims);
+    }
+
+    public Decision Update<T>(IEnumerable<Claim> claims, T target) where T : IFederated
+    {
+        return Decision.Allow("todo", claims);
+    }
+
+    public Decision Delete<T>(IEnumerable<Claim> claims, T target) where T : IFederated
+    {
+        return Decision.Allow("todo", claims);
+    }
+
+    public Decision Attribute<T>(IEnumerable<Claim> claims, T target, Profile attributeTo) where T : IFederated
+    {
+        return Decision.Allow("todo", claims);
+    }
+
+    public Decision Publish<T>(IEnumerable<Claim> claims, T target) where T : IFederated
+    {
+        return Decision.Allow("todo", claims);
+    }
+
+    public Decision View<T>(IEnumerable<Claim> claims, T target) where T : IFederated
+    {
+        return Decision.Allow("todo", claims);
+    }
+
+    public Decision Report<T>(IEnumerable<Claim> claims, T target) where T : IFederated
+    {
+        return Decision.Allow("todo", claims);
+    }
+}

--- a/Letterbook.Core/Authorization/Decision.cs
+++ b/Letterbook.Core/Authorization/Decision.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Immutable;
+using System.Security.Claims;
+
+namespace Letterbook.Core.Authorization;
+
+public class Decision
+{
+    protected readonly HashSet<Claim> Supporting = new();
+    protected readonly HashSet<Claim> Disqualifying = new();
+    protected readonly HashSet<Claim> Other = new();
+    protected bool IsAllowed;
+    protected string? OverrideReason;
+    
+    protected Decision()
+    {
+        IsAllowed = false;
+    }
+
+    public static Decision Allow(string reason, IEnumerable<Claim>? claims) =>
+        new DecisionBuilder(claims).Decide(true, reason);
+    
+    public static Decision Deny(string reason, IEnumerable<Claim>? claims) =>
+        new DecisionBuilder(claims).Decide(false, reason);
+
+    public bool Allowed => IsAllowed;
+
+    public string? Reason => OverrideReason;
+
+    public IReadOnlyCollection<Claim> SupportingClaims => Supporting.ToImmutableHashSet();
+
+    public IReadOnlyCollection<Claim> DisqualifyingClaims => Disqualifying.ToImmutableHashSet();
+
+    public IReadOnlyCollection<Claim> OtherClaims => Other.ToImmutableHashSet();
+
+    public static implicit operator bool(Decision d) => d.IsAllowed;
+}

--- a/Letterbook.Core/Authorization/DecisionBuilder.cs
+++ b/Letterbook.Core/Authorization/DecisionBuilder.cs
@@ -1,0 +1,49 @@
+﻿using System.Security.Claims;
+
+namespace Letterbook.Core.Authorization;
+
+public class DecisionBuilder : Decision
+{
+    private readonly HashSet<Claim> _allClaims = new();
+
+    public DecisionBuilder(IEnumerable<Claim>? allClaims = null)
+    {
+        if (allClaims is not null)
+            _allClaims.UnionWith(allClaims);
+    }
+
+    public void SupportedBy(Claim claim)
+    {
+        Supporting.Add(claim);
+        _allClaims.Add(claim);
+    }
+
+    public void DisqualifiedBy(Claim claim)
+    {
+        Disqualifying.Add(claim);
+        _allClaims.Add(claim);
+    }
+
+    public Decision Decide(bool decision, string reason)
+    {
+        Decide();
+        OverrideReason = reason;
+        IsAllowed = decision;
+
+        return this;
+    }
+
+    public Decision Decide()
+    {
+        Other.UnionWith(_allClaims);
+        Other.ExceptWith(Supporting);
+        Other.ExceptWith(Disqualifying);
+        Supporting.ExceptWith(Disqualifying);
+        Disqualifying.ExceptWith(Supporting);
+
+        IsAllowed = Disqualifying.Count == 0;
+
+        return this;
+    }
+    
+}

--- a/Letterbook.Core/IAuthorizationService.cs
+++ b/Letterbook.Core/IAuthorizationService.cs
@@ -1,0 +1,21 @@
+﻿using System.Security.Claims;
+using Letterbook.Core.Authorization;
+using Letterbook.Core.Models;
+
+namespace Letterbook.Core;
+
+public interface IAuthorizationService
+{
+    public Decision Create<T>(IEnumerable<Claim> claims, T target) where T : IFederated;
+    public Decision Update<T>(IEnumerable<Claim> claims, T target) where T : IFederated;
+    public Decision Delete<T>(IEnumerable<Claim> claims, T target) where T : IFederated;
+    public Decision Attribute<T>(IEnumerable<Claim> claims, T target, Profile attributeTo) where T : IFederated;
+    public Decision Publish<T>(IEnumerable<Claim> claims, T target) where T : IFederated;
+    public Decision View<T>(IEnumerable<Claim> claims, T target) where T : IFederated;
+    public Decision Report<T>(IEnumerable<Claim> claims, T target) where T : IFederated;
+    
+    // TODO: collections/tags/whatever we call them
+    // TODO: account stuff
+    // TODO: profile stuff (notifications, follows, blocks, etc)
+    // TODO: thread stuff (manage replies, maybe more)
+}


### PR DESCRIPTION
Adds a dedicated authorization service, to encapsulate authorization decisions. For now everything is always allowed, but we can fill in some more meaningful logic later. This will also make authz logic much more consistent and testable.

## Details
- Most other services should depend on this one, and call one or more of the relevant decision methods to make authz decisions.

## Related
- re: #167