### PR TITLE
Remove this dangling folder include

### DIFF
--- a/Letterbook.Adapter.ActivityPub.Test/Letterbook.Adapter.ActivityPub.Test.csproj
+++ b/Letterbook.Adapter.ActivityPub.Test/Letterbook.Adapter.ActivityPub.Test.csproj
@@ -42,8 +42,4 @@
       </None>
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Fixtures\" />
-    </ItemGroup>
-
 </Project>


### PR DESCRIPTION
  What is the purpose of this PR? What does it do, and how?


Remove this dangling folder include for `Fixtures` from `Letterbook.Adapter.ActivityPub.Test.csproj` The folder does not exist.
If it did, it would be included by default, There is in most cases no need to manually include a folder
This is likely cruft, unless there is a specific reason for it (such as generated code?)


## Details
- Are there any technical details you need to explain?
- New patterns, or deviations from existing patterns?

## Related
- link issues, this helps when preparing release notes
- use closing keywords, if appropriate
