### PR TITLE
Remove cruft from csproj files

### DIFF
--- a/Letterbook.Api.Tests/Letterbook.Api.Tests.csproj
+++ b/Letterbook.Api.Tests/Letterbook.Api.Tests.csproj
@@ -41,8 +41,4 @@
     <ProjectReference Include="..\Letterbook.Core.Tests\Letterbook.Core.Tests.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Fakes\" />
-  </ItemGroup>
-
 </Project>

--- a/Letterbook.Api/Letterbook.Api.csproj
+++ b/Letterbook.Api/Letterbook.Api.csproj
@@ -52,12 +52,4 @@
     <ProjectReference Include="..\Letterbook.Core\Letterbook.Core.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Mappers\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Remove="Controllers\WebFingerController.cs" />
-  </ItemGroup>
-
 </Project>

--- a/Letterbook.Core.Tests/Letterbook.Core.Tests.csproj
+++ b/Letterbook.Core.Tests/Letterbook.Core.Tests.csproj
@@ -43,6 +43,4 @@
         <ProjectReference Include="..\Letterbook.Core\Letterbook.Core.csproj" />
     </ItemGroup>
 
-
-
 </Project>

--- a/Letterbook.Core/Letterbook.Core.csproj
+++ b/Letterbook.Core/Letterbook.Core.csproj
@@ -28,8 +28,4 @@
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Mappers\" />
-    </ItemGroup>
-
 </Project>


### PR DESCRIPTION
  What is the purpose of this PR? What does it do, and how?

Remove cruft from csproj files

* `Letterbook.Api.Tests/Fakes` Folder does not exist, and if it did, it would be included by default. Including it explicitly has no effect.
* `Letterbook.Api/Mappers`  Folder does not exist, same.
* `Letterbook.Core/Mappers`  Folder does not exist, same.
* `Letterbook.Api/Controllers/WebFingerController.cs` File does not exist, removing it in csproj has no effect.
* `Letterbook.Core.Tests/Letterbook.Core.Tests.csproj` removed extra spaces

## Details
- Are there any technical details you need to explain?
- New patterns, or deviations from existing patterns?

No.

## Related
- link issues, this helps when preparing release notes
- use closing keywords, if appropriate
