### PR TITLE
Cleanup unused imports

### DIFF
--- a/Letterbook.Adapter.ActivityPub/Letterbook.Adapter.ActivityPub.csproj
+++ b/Letterbook.Adapter.ActivityPub/Letterbook.Adapter.ActivityPub.csproj
@@ -16,7 +16,6 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="NJsonSchema.CodeGeneration.CSharp" Version="10.9.0" />
       <PackageReference Include="NSign.Abstractions" Version="0.19.1" />
       <PackageReference Include="NSign.Client" Version="0.19.1" />
       <PackageReference Include="NSign.SignatureProviders" Version="0.19.1" />

--- a/Letterbook.Api.IntegrationTests/Letterbook.Api.IntegrationTests.csproj
+++ b/Letterbook.Api.IntegrationTests/Letterbook.Api.IntegrationTests.csproj
@@ -10,7 +10,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="JsonDiffPatch.Net" Version="2.3.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.10" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
         <PackageReference Include="xunit" Version="2.7.0"/>

--- a/Letterbook.Api.Tests/Letterbook.Api.Tests.csproj
+++ b/Letterbook.Api.Tests/Letterbook.Api.Tests.csproj
@@ -16,7 +16,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JsonDiffPatch.Net" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.10" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.8.0">

--- a/Letterbook.Core/Letterbook.Core.csproj
+++ b/Letterbook.Core/Letterbook.Core.csproj
@@ -25,7 +25,6 @@
       <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="8.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
       <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.2.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Over time, some packages snuck into our imports that we don't actually use. This removes them.

## Details
- Newtonsoft
- JsonDiffPatch
- NJsonSchema

(huh, it's all json)