### PR TITLE
Update node github Actions to V4

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
       


### PR DESCRIPTION
##  What is the purpose of this PR? What does it do, and how?

Update node github Actions to V4
As these currently run on Node.js 16, which is deprecated in favour actions on of Node.js 20

Note the message here: https://github.com/Letterbook/Letterbook/actions/runs/8119876091

![image](https://github.com/Letterbook/Letterbook/assets/104187/08ddc8e5-91bf-42de-a231-7539c205de8c)

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: 
actions/checkout@v3, actions/setup-dotnet@v3. 
For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```
Intent is to remove this warning.

## Details

This node version update is documented on the release pages of these actions for v4:

`actions/checkout`: https://github.com/actions/checkout/releases

`actions/setup-dotnet`: https://github.com/actions/setup-dotnet/releases

There have been multiple rounds of this, the latest GHA node version seems to change every 6 months. Node 16 will eventually stop working or give more severe issues such as slowdown. By updating, we stave off entropy for a short while longer.

## Related

We can see that the "build pull request" action works on the PR, as that will use the updated `pull-request.yml` file on this branch: Note use of V4 actions here: https://github.com/Letterbook/Letterbook/actions/runs/8123862255/job/22204717315?pr=178

