### PR TITLE
Add a basic .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.cs]
+charset = utf-8
+indent_style = space
+indent_size = 4
+max_line_length = 240
+insert_final_newline = false
+trim_trailing_whitespace = true


### PR DESCRIPTION
  What is the purpose of this PR? What does it do, and how?

Add a basic .editorconfig file

## Details

* covers only `.cs` files
* Covers only basic formatting: 
  * utf-8
  * 4 spaces not tabs
  * No trailing newline at end of file (simply cause that's what the existing files look like)
  * No trailing whitespace at end of line
  * LF / CRLF not configured, as in my experience it's better to let Git take care of that and not have the two tools fight over it, that does not end well. 

There will be initial changes because of this when files are worked on,  specifically the " trailing whitespace at end of line" and utf-8 options. But whatever option you pick, that will happen as files fall into line

It is possible to extend this, in 2 directions
- there are loads of [dotnet code-style rule options](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options) that are supported by some dotnet tools.
- cover other file types that are used in the repo.

But these are not needed initially.

## Related

https://editorconfig.org/

https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options
