### PR TITLE
Organize Swagger docs

### DIFF
--- a/Letterbook.Api/Controllers/ActivityPub/ActorController.cs
+++ b/Letterbook.Api/Controllers/ActivityPub/ActorController.cs
@@ -5,10 +5,10 @@ using Letterbook.Adapter.ActivityPub;
 using Letterbook.Adapter.ActivityPub.Mappers;
 using Letterbook.Adapter.ActivityPub.Types;
 using Letterbook.Api.Dto;
+using Letterbook.Api.Swagger;
 using Letterbook.Core;
 using Letterbook.Core.Adapters;
 using Letterbook.Core.Exceptions;
-using Letterbook.Core.Extensions;
 using Letterbook.Core.Values;
 using Medo;
 using Microsoft.AspNetCore.Mvc;
@@ -20,6 +20,7 @@ namespace Letterbook.Api.Controllers.ActivityPub;
 /// Provides the endpoints specified for Actors in the ActivityPub spec
 /// https://www.w3.org/TR/activitypub/#actors
 /// </summary>
+[ApiExplorerSettings(GroupName = Docs.ActivityPubV1)]
 [ApiController]
 [Route("[controller]")]
 [Consumes("application/ld+json",

--- a/Letterbook.Api/Controllers/ActivityPub/ObjectController.cs
+++ b/Letterbook.Api/Controllers/ActivityPub/ObjectController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Letterbook.Api.Swagger;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Letterbook.Api.Controllers.ActivityPub;
 
@@ -6,6 +7,7 @@ namespace Letterbook.Api.Controllers.ActivityPub;
 /// Provides the Collection endpoints specified for all objects in the ActivityPub spec
 /// https://www.w3.org/TR/activitypub/#collections
 /// </summary>
+[ApiExplorerSettings(GroupName = Docs.ActivityPubV1)]
 [ApiController]
 [Route("[controller]/{type}")]
 public class ObjectController

--- a/Letterbook.Api/Controllers/Debugging/DebugController.cs
+++ b/Letterbook.Api/Controllers/Debugging/DebugController.cs
@@ -1,4 +1,5 @@
-﻿using Letterbook.Core;
+﻿using Letterbook.Api.Swagger;
+using Letterbook.Core;
 using Letterbook.Core.Extensions;
 using Medo;
 using Microsoft.AspNetCore.Mvc;
@@ -8,6 +9,7 @@ namespace Letterbook.Api.Controllers.Debugging;
 /// <summary>
 /// A temporary controller to make it easier to trigger the actions we want to test
 /// </summary>
+[ApiExplorerSettings(GroupName = Docs.LetterbookV1)]
 public class DebugController : ControllerBase
 {
     private readonly IProfileService _profileService;

--- a/Letterbook.Api/Controllers/Mastodon/AccountsController.cs
+++ b/Letterbook.Api/Controllers/Mastodon/AccountsController.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Letterbook.Api.Swagger;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Letterbook.Api.Controllers.Mastodon;
 
+[ApiExplorerSettings(GroupName = Docs.MastodonV1)]
 [Route("api/v1/[controller]")]
 public class AccountsController
 {

--- a/Letterbook.Api/Controllers/UserAccountController.cs
+++ b/Letterbook.Api/Controllers/UserAccountController.cs
@@ -2,6 +2,7 @@
 using System.Security.Claims;
 using System.Text;
 using Letterbook.Api.Dto;
+using Letterbook.Api.Swagger;
 using Letterbook.Core;
 using Letterbook.Core.Exceptions;
 using Letterbook.Core.Extensions;
@@ -12,7 +13,8 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace Letterbook.Api.Controllers;
 
-[Route("/api/v1/[controller]/[action]")]
+[ApiExplorerSettings(GroupName = Docs.LetterbookV1)]
+[Route("/lb/v1/[controller]/[action]")]
 public class UserAccountController : ControllerBase
 {
     private readonly ILogger<UserAccountController> _logger;

--- a/Letterbook.Api/Dto/Id25.cs
+++ b/Letterbook.Api/Dto/Id25.cs
@@ -1,0 +1,28 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Medo;
+
+namespace Letterbook.Api.Dto;
+
+public struct Id25
+{
+    private string _id;
+    public override string ToString() => _id;
+
+    public static implicit operator Id25(Uuid7 v) => new() { _id = v.ToId25String() };
+    public static implicit operator Id25(string v) => new() { _id = v };
+    public static implicit operator string(Id25 v) => v._id;
+    
+    public bool TryAsUuid7(out Uuid7 id)
+    {
+        try
+        {
+            id = Uuid7.FromId25String(_id);
+            return true;
+        }
+        catch (Exception)
+        {
+            id = Uuid7.Empty;
+            return false;
+        }
+    }
+}

--- a/Letterbook.Api/Swagger/DependencyInjection.cs
+++ b/Letterbook.Api/Swagger/DependencyInjection.cs
@@ -1,0 +1,90 @@
+﻿using Letterbook.Api.Dto;
+using Medo;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerUI;
+
+namespace Letterbook.Api.Swagger;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection ConfigureSwagger(this IServiceCollection services)
+    {
+        // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+        return services.AddEndpointsApiExplorer()
+            .AddSwaggerGen(options =>
+        {
+            options.SwaggerDoc(Docs.LetterbookV1Desc.Name,
+                new OpenApiInfo
+                {
+                    Title = "Letterbook APIs",
+                    Description = "Letterbook's first party API",
+                    Version = "v1",
+                    Contact = new() { Url = new Uri("https://letterbookhq.com") }
+                });
+            options.SwaggerDoc(Docs.MastodonV1Desc.Name,
+                new OpenApiInfo
+                {
+                    Title = "Mastodon APIs",
+                    Description = "Letterbook's implementation of the Mastodon APIs",
+                    Version = "v1",
+                    Contact = new() { Url = new Uri("https://docs.joinmastodon.com") }
+                });
+            options.SwaggerDoc(Docs.ActivityPubV1Desc.Name,
+                new OpenApiInfo
+                {
+                    Title = "ActivityPub endpoints",
+                    Version = "v1",
+                    Description = "ActivityPub objects and specified endpoints",
+                    Contact = new() { Url = new Uri("https://www.w3.org/TR/activitypub/") }
+                });
+            options.MapType<Uuid7>(() => new OpenApiSchema{Type = "string", Format = "uuid"});
+            options.MapType<Id25>(() => new OpenApiSchema
+            {
+                Type = "string",
+                Pattern = "[0-9a-z]{25}",
+                Example = new OpenApiString(Uuid7.NewUuid7().ToId25String())
+            });
+            options.AddSecurityDefinition(name: "Bearer", securityScheme: new OpenApiSecurityScheme
+            {
+                Name = "Authorization",
+                Description = "Enter the Authorization header, including the Bearer scheme, like so: `Bearer <JWT>`",
+                In = ParameterLocation.Header,
+                Type = SecuritySchemeType.ApiKey,
+                Scheme = "Bearer"
+            });
+            options.AddSecurityRequirement(new OpenApiSecurityRequirement()
+            {
+                {
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = "Bearer"
+                        },
+                        Scheme = "oauth2",
+                        Name = "Bearer",
+                        In = ParameterLocation.Header,
+                    },
+                    new List<string>()
+                }
+            });
+            options.OperationFilter<RequiredHeaders>();
+        });
+    }
+
+    public static void UseSwaggerConfig(this WebApplication app)
+    {
+        app.UseSwagger();
+        app.UseSwaggerUI(opts =>
+        {
+            opts.ConfigObject.Urls = new List<UrlDescriptor>()
+            {
+                Docs.LetterbookV1Desc,
+                Docs.MastodonV1Desc,
+                Docs.ActivityPubV1Desc
+            };
+        });
+    }
+}

--- a/Letterbook.Api/Swagger/Docs.cs
+++ b/Letterbook.Api/Swagger/Docs.cs
@@ -1,0 +1,13 @@
+﻿using Swashbuckle.AspNetCore.SwaggerUI;
+
+namespace Letterbook.Api.Swagger;
+
+public static class Docs
+{
+    public const string LetterbookV1 = "letterbook-v1";
+    public const string MastodonV1 = "mastodon-v1";
+    public const string ActivityPubV1 = "activity-pub-v1";
+    public static UrlDescriptor LetterbookV1Desc = new (){Name = LetterbookV1, Url = $"{LetterbookV1}/swagger.json"};
+    public static UrlDescriptor MastodonV1Desc = new (){Name = MastodonV1, Url = $"{MastodonV1}/swagger.json"};
+    public static UrlDescriptor ActivityPubV1Desc = new (){Name = ActivityPubV1, Url = $"{ActivityPubV1}/swagger.json"};
+}


### PR DESCRIPTION
This allows us to generate multiple OpenAPI docs, and swap between them in the Swagger UI. This should give a more focused experience when interacting with the Swagger UI.

![image](https://github.com/Letterbook/Letterbook/assets/8325540/507dfc06-dc83-4e67-a9c5-77e71eb4a668)

## Details
- Generate multiple swagger.json files:
  - letterbook-v1
  - mastodon-v1
  - activity-pub-v1
- Configure the swagger UI to load and swap between them using the definition selector
- Move the (now extensive) swagger config into DI extension methods
