### PR TITLE
Fix race while reading test data files

### DIFF
--- a/Letterbook.Adapter.ActivityPub.Test/ClientTests.cs
+++ b/Letterbook.Adapter.ActivityPub.Test/ClientTests.cs
@@ -142,14 +142,16 @@ public class ClientTests : WithMocks, IClassFixture<JsonLdSerializerFixture>
 	[Fact(DisplayName = "Should fetch a profile and successfully deserialize it")]
 	public async Task FetchProfile()
 	{
+		await using var fs = TestData.Read("Actor.json");
+		var sc = new StreamContent(fs)
+		{
+			Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
+		};
 		HttpMessageHandlerMock
 			.SetupResponse(r =>
 			{
 				r.StatusCode = HttpStatusCode.OK;
-				r.Content = new StreamContent(TestData.Read("Actor.json"))
-				{
-					Headers = { ContentType = new MediaTypeHeaderValue("application/json") }
-				};
+				r.Content = sc;
 			});
 
 		var profile = await _client.As(_profile).Fetch<Models.Profile>(new Uri("http://mastodon.example/users/user"));

--- a/Letterbook.Adapter.ActivityPub.Test/TestData.cs
+++ b/Letterbook.Adapter.ActivityPub.Test/TestData.cs
@@ -9,6 +9,6 @@ public static class TestData
 
 	public static Stream Read(string fileName)
 	{
-		return new FileStream(Path.Join(DataDir, fileName), FileMode.Open);
+		return new FileStream(Path.Join(DataDir, fileName), FileMode.Open, FileAccess.Read, FileShare.Read);
 	}
 }


### PR DESCRIPTION
Small fix for a race condition in the tests

## Details
- Now that multiple test projects depend on the Actor.json test data file, they might try to read it at the same time
- This change permits them to do so
- Previously, one of them would sometimes throw

