### PR TITLE
Refactor Profile service to support future authz

### DIFF
--- a/Letterbook.Adapter.ActivityPub.Test/TestData.cs
+++ b/Letterbook.Adapter.ActivityPub.Test/TestData.cs
@@ -9,6 +9,6 @@ public static class TestData
 
 	public static Stream Read(string fileName)
 	{
-		return new FileStream(Path.Join(DataDir, fileName), FileMode.Open);
+		return new FileStream(Path.Join(DataDir, fileName), FileMode.Open, FileAccess.Read, FileShare.Read);
 	}
 }

--- a/Letterbook.Api.Tests/ActorControllerTests.cs
+++ b/Letterbook.Api.Tests/ActorControllerTests.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 
 namespace Letterbook.Api.Tests;
 
-public class ActorControllerTests : WithMocks
+public class ActorControllerTests : WithMockContext
 {
 	private ITestOutputHelper _output;
 	private ActorController _controller;
@@ -27,7 +27,13 @@ public class ActorControllerTests : WithMocks
 	{
 		_output = output;
 		_controller = new ActorController(CoreOptionsMock, Mock.Of<ILogger<ActorController>>(),
-			ProfileServiceMock.Object, Mock.Of<IActivityMessageService>(), new Document());
+			ProfileServiceMock.Object, Mock.Of<IActivityMessageService>(), new Document())
+		{
+			ControllerContext = new ControllerContext()
+			{
+				HttpContext = MockHttpContext.Object
+			}
+		};
 
 		_output.WriteLine($"Bogus Seed: {Init.WithSeed()}");
 		_fakeProfile = new FakeProfile("http://letterbook.example");
@@ -54,7 +60,7 @@ public class ActorControllerTests : WithMocks
 		var activity = _document.Follow(_remoteProfile, _profile);
 		activity.Object.Add(_profile.FediId);
 
-		ProfileServiceMock.Setup(service =>
+		ProfileServiceAuthMock.Setup(service =>
 				service.ReceiveFollowRequest(_profile.Id, _remoteProfile.FediId, It.IsAny<Uri?>()))
 			.ReturnsAsync(BuildRelation(FollowState.Accepted));
 
@@ -69,7 +75,7 @@ public class ActorControllerTests : WithMocks
 		var activity = _document.Follow(_remoteProfile, _profile);
 		activity.Object.Add(_profile.FediId);
 
-		ProfileServiceMock.Setup(service =>
+		ProfileServiceAuthMock.Setup(service =>
 				service.ReceiveFollowRequest(_profile.GetId(), _remoteProfile.FediId, It.IsAny<Uri?>()))
 			.ReturnsAsync(BuildRelation(FollowState.Pending));
 
@@ -84,7 +90,7 @@ public class ActorControllerTests : WithMocks
 		var activity = _document.Follow(_remoteProfile, _profile);
 		activity.Object.Add(_profile.FediId);
 
-		ProfileServiceMock.Setup(service =>
+		ProfileServiceAuthMock.Setup(service =>
 				service.ReceiveFollowRequest(_profile.Id, _remoteProfile.FediId, null))
 			.ReturnsAsync(BuildRelation(FollowState.Rejected));
 

--- a/Letterbook.Api.Tests/ProfileControllerTests.cs
+++ b/Letterbook.Api.Tests/ProfileControllerTests.cs
@@ -1,0 +1,33 @@
+﻿using Letterbook.Api.Controllers;
+using Letterbook.Api.Dto;
+using Medo;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Letterbook.Api.Tests;
+
+public class ProfileControllerTests : WithMockContext
+{
+	private readonly ProfileController _controller;
+
+	public ProfileControllerTests()
+	{
+		_controller = new ProfileController(Mock.Of<ILogger<ProfileController>>(), CoreOptionsMock, ProfileServiceMock.Object);
+	}
+
+	[Fact]
+	public void Exists()
+	{
+		Assert.NotNull(_controller);
+	}
+
+	[Fact(Skip = "Not implemented")]
+	public async Task CanGetProfile()
+	{
+		var result = await _controller.Get(Uuid7.NewUuid7());
+
+		var response = Assert.IsType<OkObjectResult>(result);
+		var actual = Assert.IsType<FullProfileDto>(response.Value);
+	}
+}

--- a/Letterbook.Api.Tests/WebfingerTests.cs
+++ b/Letterbook.Api.Tests/WebfingerTests.cs
@@ -29,7 +29,7 @@ public class WebfingerTests : WithMocks
 	[Fact(DisplayName = "Should return the descriptor")]
 	public async Task GetsDescriptor()
 	{
-		ProfileServiceMock.Setup(m => m.FindProfiles(_profile.Handle))
+		ProfileServiceAuthMock.Setup(m => m.FindProfiles(_profile.Handle))
 			.ReturnsAsync(new List<Models.Profile> { _profile });
 
 		var actual = await _provider.GetResourceDescriptorAsync(new Uri($"acct:{_profile.Handle}@letterbook.example"),
@@ -43,7 +43,7 @@ public class WebfingerTests : WithMocks
 	[Fact(DisplayName = "Should not return a descriptor when no profiles are found")]
 	public async Task GetsNoDescriptor()
 	{
-		ProfileServiceMock.Setup(m => m.FindProfiles(_profile.Handle))
+		ProfileServiceAuthMock.Setup(m => m.FindProfiles(_profile.Handle))
 			.ReturnsAsync(Array.Empty<Models.Profile>());
 
 		var actual = await _provider.GetResourceDescriptorAsync(new Uri($"acct:{_profile.Handle}@letterbook.example"),
@@ -58,7 +58,7 @@ public class WebfingerTests : WithMocks
 		var req = new Mock<HttpRequest>();
 		req.SetupGet<IHeaderDictionary>(m => m.Headers).Returns(new HeaderDictionary());
 
-		ProfileServiceMock.Setup(m => m.FindProfiles(_profile.Handle))
+		ProfileServiceAuthMock.Setup(m => m.FindProfiles(_profile.Handle))
 			.ReturnsAsync(Array.Empty<Models.Profile>());
 
 		var actual = await _provider.GetResourceDescriptorAsync(new Uri($"acct:{_profile.Handle}"),

--- a/Letterbook.Api/Controllers/ActivityPub/ActorController.cs
+++ b/Letterbook.Api/Controllers/ActivityPub/ActorController.cs
@@ -53,7 +53,7 @@ public class ActorController : ControllerBase
 		if (!Id.TryAsUuid7(id, out var uuid))
 			return BadRequest();
 
-		var profile = await _profileService.LookupProfile(uuid);
+		var profile = await _profileService.As(User.Claims).LookupProfile(uuid);
 		if (profile == null) return NotFound();
 		var actor = ActorMapper.Map<PersonActorExtension>(profile);
 
@@ -184,7 +184,7 @@ public class ActorController : ControllerBase
 			if (!actor.TryGetId(out var actorId))
 				return new BadRequestObjectResult(new ErrorMessage(ErrorCodes.InvalidRequest,
 					"Actor ID is required to Undo:Follow"));
-			await _profileService.RemoveFollower(id, actorId);
+			await _profileService.As(User.Claims).RemoveFollower(id, actorId);
 			return new OkResult();
 		}
 		if (activityObject.Is<LikeActivity>(out var likeActivity))
@@ -202,7 +202,7 @@ public class ActorController : ControllerBase
 			return BadRequest(new ErrorMessage(ErrorCodes.None, "Actor ID is required for follower"));
 
 		followRequest.TryGetId(out var activityId);
-		var relation = await _profileService.ReceiveFollowRequest(localId, actorId, activityId);
+		var relation = await _profileService.As(User.Claims).ReceiveFollowRequest(localId, actorId, activityId);
 
 		ASType resultActivity = relation.State switch
 		{

--- a/Letterbook.Api/Controllers/Debugging/DebugController.cs
+++ b/Letterbook.Api/Controllers/Debugging/DebugController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Letterbook.Api.Swagger;
 using Letterbook.Core;
 using Letterbook.Core.Extensions;
@@ -33,7 +34,7 @@ public class DebugController : ControllerBase
 			return BadRequest();
 		}
 
-		var result = await _profileService.Follow(localId, new Uri(target.TargetId));
+		var result = await _profileService.As(Enumerable.Empty<Claim>()).Follow(localId, new Uri(target.TargetId));
 
 		return Ok(result);
 	}

--- a/Letterbook.Api/Controllers/ProfileController.cs
+++ b/Letterbook.Api/Controllers/ProfileController.cs
@@ -1,0 +1,40 @@
+﻿using Letterbook.Api.Swagger;
+using Letterbook.Core;
+using Medo;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace Letterbook.Api.Controllers;
+
+[ApiExplorerSettings(GroupName = Docs.LetterbookV1)]
+[Route("/lb/v1/[controller]/[action]")]
+public class ProfileController : ControllerBase
+{
+	private readonly ILogger<ProfileController> _logger;
+	private readonly IOptions<CoreOptions> _options;
+	private readonly IProfileService _profiles;
+
+	public ProfileController(ILogger<ProfileController> logger, IOptions<CoreOptions> options, IProfileService profiles)
+	{
+		_logger = logger;
+		_options = options;
+		_profiles = profiles;
+	}
+
+	// get
+	[HttpGet("{profileId}")]
+	public async Task<IActionResult> Get(Uuid7 profileId)
+	{
+		var result = await _profiles.As(User.Claims).LookupProfile(profileId);
+		return result != null
+			? Ok(result)
+			: NotFound();
+	}
+	// create
+	// delete
+	// edit
+	// add field
+	// remove field
+	// edit field
+
+}

--- a/Letterbook.Api/WebfingerProvider.cs
+++ b/Letterbook.Api/WebfingerProvider.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Security.Claims;
 using System.Text.RegularExpressions;
 using DarkLink.Web.WebFinger.Server;
 using DarkLink.Web.WebFinger.Shared;
@@ -40,7 +41,7 @@ public class WebfingerProvider : IResourceDescriptorProvider
 		var handle = match.Value.Split('@', 2,
 			StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
 		if (handle == null) return default;
-		var profiles = await _profiles.FindProfiles(handle);
+		var profiles = await _profiles.As(Enumerable.Empty<Claim>()).FindProfiles(handle);
 		if (profiles.FirstOrDefault() is { } subject)
 		{
 			var descriptor = JsonResourceDescriptor.Empty with

--- a/Letterbook.Core.Tests/WithMocks.cs
+++ b/Letterbook.Core.Tests/WithMocks.cs
@@ -21,6 +21,7 @@ public abstract class WithMocks
 	protected Mock<IActivityPubClient> ActivityPubClientMock;
 	protected Mock<IActivityPubAuthenticatedClient> ActivityPubAuthClientMock;
 	protected Mock<IProfileService> ProfileServiceMock;
+	protected Mock<IAuthzProfileService> ProfileServiceAuthMock;
 	protected IOptions<CoreOptions> CoreOptionsMock;
 	protected Mock<MockableMessageHandler> HttpMessageHandlerMock;
 	protected ServiceCollection MockedServiceCollection;
@@ -40,6 +41,7 @@ public abstract class WithMocks
 		ActivityPubClientMock = new Mock<IActivityPubClient>();
 		ActivityPubAuthClientMock = new Mock<IActivityPubAuthenticatedClient>();
 		ProfileServiceMock = new Mock<IProfileService>();
+		ProfileServiceAuthMock = new Mock<IAuthzProfileService>();
 		PostEventServiceMock = new Mock<IPostEventService>();
 		PostServiceMock = new Mock<IPostService>();
 		PostServiceAuthMock = new Mock<IAuthzPostService>();
@@ -47,6 +49,7 @@ public abstract class WithMocks
 
 		ActivityPubClientMock.Setup(m => m.As(It.IsAny<Profile>())).Returns(ActivityPubAuthClientMock.Object);
 		PostServiceMock.Setup(m => m.As(It.IsAny<IEnumerable<Claim>>(), It.IsAny<Uuid7>())).Returns(PostServiceAuthMock.Object);
+		ProfileServiceMock.Setup(m => m.As(It.IsAny<IEnumerable<Claim>>())).Returns(ProfileServiceAuthMock.Object);
 		var mockOptions = new CoreOptions
 		{
 			DomainName = "letterbook.example",

--- a/Letterbook.Core/IProfileService.cs
+++ b/Letterbook.Core/IProfileService.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Letterbook.Core.Models;
 using Letterbook.Core.Values;
 using Medo;
@@ -5,6 +6,11 @@ using Medo;
 namespace Letterbook.Core;
 
 public interface IProfileService
+{
+	IAuthzProfileService As(IEnumerable<Claim> claims);
+}
+
+public interface IAuthzProfileService
 {
 	Task<Profile> CreateProfile(Profile profile);
 	Task<Profile> CreateProfile(Guid ownerId, string handle);

--- a/Letterbook.Core/ProfileService.cs
+++ b/Letterbook.Core/ProfileService.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Security.Claims;
 using Letterbook.Core.Adapters;
 using Letterbook.Core.Exceptions;
 using Letterbook.Core.Extensions;
@@ -11,7 +12,7 @@ using Microsoft.Extensions.Options;
 
 namespace Letterbook.Core;
 
-public class ProfileService : IProfileService
+public class ProfileService : IProfileService, IAuthzProfileService
 {
 	private ILogger<ProfileService> _logger;
 	private CoreOptions _coreConfig;
@@ -404,5 +405,10 @@ public class ProfileService : IProfileService
 		_logger.LogInformation("Fetched Profile {ProfileId} from origin", profileId);
 		return profile;
 
+	}
+
+	public IAuthzProfileService As(IEnumerable<Claim> claims)
+	{
+		return this;
 	}
 }


### PR DESCRIPTION
This is just some refactoring to support upcoming work on the Profile API

## Details
- Alters the `ProfileService` to implement the usual dual `IProfileService` and `IAuthzProfileService` interfaces
- Updates tests and dependents accordingly

## Related
- re #167 
- re #194 
