### PR TITLE
Add playwright test project

### DIFF
--- a/Letterbook.Web.Tests.E2E/LandingPageValidationTest.cs
+++ b/Letterbook.Web.Tests.E2E/LandingPageValidationTest.cs
@@ -1,0 +1,22 @@
+using System.Text.RegularExpressions;
+
+namespace Letterbook.Web.Tests.E2E;
+
+[Parallelizable(ParallelScope.Self)]
+[TestFixture]
+public class LandingPageValidationTest : PageTest
+{
+	[Test]
+	public async Task HomepageHasCorrectTitleAndLinksToAdminProfile()
+	{
+		await Page.GotoAsync("http://localhost:5127");
+
+		await Expect(Page).ToHaveTitleAsync(new Regex("Letterbook.Web"));
+
+		// Get link to admin profile
+		var adminProfileLink = Page.GetByRole(AriaRole.Link, new() { Name = "Admin profile" });
+
+		// Expect an attribute "to be strictly equal" to the value.
+		await Expect(adminProfileLink).ToHaveAttributeAsync("href", "/@admin");
+	}
+}

--- a/Letterbook.Web.Tests.E2E/Letterbook.Web.Tests.E2E.csproj
+++ b/Letterbook.Web.Tests.E2E/Letterbook.Web.Tests.E2E.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+        <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.43.0" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+        <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+        <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    </ItemGroup>
+
+</Project>

--- a/Letterbook.Web.Tests.E2E/README.md
+++ b/Letterbook.Web.Tests.E2E/README.md
@@ -1,0 +1,32 @@
+﻿# E2E Testing for Letterbook.Web
+
+> Note: this project is using **NUnit** not **XUnit** like other test projects we use.
+
+## Setup
+
+This test package uses [Playwright](https://playwright.dev). While most dependencies are provided automatically for you, Playwright will require you to install test browsers to run these tests.
+
+You can find out more about this at https://playwright.dev/dotnet/docs/intro
+
+Or use
+
+```shell
+dotnet build
+pwsh bin/Debug/netX/playwright.ps1 install
+```
+
+To install browser dependencies. This requires powershell to be installed.
+
+> Note: You need to replace `netX` above with the version of .NET you are using. For example `pwsh .\bin\Debug\net7.0\playwright.ps1 install`
+
+## Common Errors
+
+### Executable doesn't exist at **/chrome.exe | **/firefox.exe
+
+Playwright uses custom headless versions of common browsers to execute its tests. If your seeing an error that chrome/firefox etc can not be found this does not mean you need to reinstall your browsers. Instead you'll need to run the configuration script provided by Playwright to install the necessary browsers for the test clients to run.
+
+Playwright should have provided a hint to install the needed browser tooling or you can use the Setup steps above.
+
+### The argument 'bin/Debug/netX/playwright.ps1' is not recognized as the name of a script file.
+
+`netX` is a placeholder for the version of .NET you are using. You should replace that with the correct version and try again.

--- a/Letterbook.Web.Tests.E2E/Usings.cs
+++ b/Letterbook.Web.Tests.E2E/Usings.cs
@@ -1,0 +1,3 @@
+global using NUnit.Framework;
+global using Microsoft.Playwright;
+global using Microsoft.Playwright.NUnit;

--- a/Letterbook.sln
+++ b/Letterbook.sln
@@ -73,6 +73,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Http", "Http", "{1D8F2C94-1
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Letterbook.Web", "Letterbook.Web\Letterbook.Web.csproj", "{CA5F8A6B-4388-41EA-91FB-45C9A7A53E17}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Letterbook.Web.Tests.E2E", "Letterbook.Web.Tests.E2E\Letterbook.Web.Tests.E2E.csproj", "{BAC147EA-8CB8-46C0-B7B8-C30E150879B6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -138,6 +140,10 @@ Global
 		{CA5F8A6B-4388-41EA-91FB-45C9A7A53E17}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CA5F8A6B-4388-41EA-91FB-45C9A7A53E17}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CA5F8A6B-4388-41EA-91FB-45C9A7A53E17}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BAC147EA-8CB8-46C0-B7B8-C30E150879B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BAC147EA-8CB8-46C0-B7B8-C30E150879B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BAC147EA-8CB8-46C0-B7B8-C30E150879B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BAC147EA-8CB8-46C0-B7B8-C30E150879B6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{25C320AC-E149-44F9-81F3-5275C7D8D334} = {DFA1FACC-AC5C-4B25-A0E4-718957C70BC3}


### PR DESCRIPTION
Creates a project for #205 and adds a quick Playwright test project.

Still needs GitHub action integration - this only runs locally right now.


Playwright isn't well supported in XUnit, This project is built on top of NUnit. We could probably get XUnit to work here, but it'd have a number of limitations and would require a descent amount of work to orchestrate the parts Playwright is doing for us automatically in NUnit (or MSTest).