### PR TITLE
basic profile display

### DIFF
--- a/Letterbook.Web/Pages/Profile.cshtml
+++ b/Letterbook.Web/Pages/Profile.cshtml
@@ -4,10 +4,32 @@
 @{
     ViewData["Title"] = Model.Handle;
 }
-<div class="text-center">
-    <h1 class="display-4">@Model.Handle Profile Page</h1>
+
+<div>
+    <h1>
+        <span>@Model.DisplayName</span>
+        <span>@@@Model.Handle</span>
+    </h1>
+    
+    <div>
+        <div>@Html.Raw(@Model.Description)</div>
+        
+        <dl>
+            @foreach (var field in @Model.CustomFields) {
+                <dt>@field.Label</dt>
+                <dd>@field.Value</dd>
+            }
+        </dl>
+        
+        <div>
+            <div>
+                @Model.GetFollowerCount Followers
+            </div>
+            <div>
+                @Model.GetFollowingCount Following
+            </div>
+        </div>
+        
+    </div>
+    
 </div>
-<article>
-    <p class="content">ID: @Model.Prof.GetId25()</p>
-    <code>@Model.Json</code>
-</article>

--- a/Letterbook.Web/Pages/Profile.cshtml
+++ b/Letterbook.Web/Pages/Profile.cshtml
@@ -2,17 +2,17 @@
 @model Letterbook.Web.Pages.Profile
 
 @{
-    ViewData["Title"] = Model.Handle;
+    ViewData["Title"] = $"{Model.DisplayName} ({Model.Handle})";
 }
 
 <div>
     <h1>
         <span>@Model.DisplayName</span>
-        <span>@@@Model.Handle</span>
+        <span>@Model.Handle</span>
     </h1>
     
     <div>
-        <div>@Html.Raw(@Model.Description)</div>
+        <div>@Model.Description</div>
         
         <dl>
             @foreach (var field in @Model.CustomFields) {
@@ -23,10 +23,10 @@
         
         <div>
             <div>
-                @Model.GetFollowerCount Followers
+                @Model.GetFollowerCount() Followers
             </div>
             <div>
-                @Model.GetFollowingCount Following
+                @Model.GetFollowingCount() Following
             </div>
         </div>
         

--- a/Letterbook.Web/Pages/Profile.cshtml.cs
+++ b/Letterbook.Web/Pages/Profile.cshtml.cs
@@ -2,27 +2,31 @@
 using Models = Letterbook.Core.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Html;
+using Microsoft.Extensions.Options;
 
 namespace Letterbook.Web.Pages;
 
 public class Profile : PageModel
 {
 	private readonly IProfileService _profiles;
+	private readonly CoreOptions _options;
 	
 	public required string Handle { get; set; }
 	public required string DisplayName { get; set; }
-	public required string Description { get; set; }
+	public required HtmlString Description { get; set; }
 	public required Models.CustomField[] CustomFields { get; set; }
 	
 	private protected Models.Profile? Prof { get; set; }
 	
-	public int GetFollowerCount => Prof!.FollowersCollection.Count;
-	public int GetFollowingCount => Prof!.FollowingCollection.Count;
+	public int GetFollowerCount() => Prof!.FollowersCollection.Count;
+	public int GetFollowingCount() => Prof!.FollowingCollection.Count;
 
 
-	public Profile(IProfileService profiles)
+	public Profile(IProfileService profiles, IOptions<CoreOptions> options)
 	{
 		_profiles = profiles;
+		_options = options.Value;
 	}
 
 	public async Task<IActionResult> OnGet(string handle)
@@ -31,9 +35,10 @@ public class Profile : PageModel
 		if (found.FirstOrDefault() is not { } profile)
 			return NotFound();
 		Prof = profile;
-		Handle = handle;
+		
+		Handle = $"@{handle}@{_options.DomainName}";
 		DisplayName = profile.DisplayName;
-		Description = profile.Description;
+		Description = new HtmlString(profile.Description);
 		CustomFields = profile.CustomFields;
 
 

--- a/Letterbook.Web/Pages/Profile.cshtml.cs
+++ b/Letterbook.Web/Pages/Profile.cshtml.cs
@@ -1,9 +1,4 @@
-﻿using System.Text.Json;
-using System.Text.Json.Serialization;
-using AutoMapper;
-using Letterbook.Api.Dto;
-using Letterbook.Api.Mappers;
-using Letterbook.Core;
+﻿using Letterbook.Core;
 using Models = Letterbook.Core.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -13,16 +8,21 @@ namespace Letterbook.Web.Pages;
 public class Profile : PageModel
 {
 	private readonly IProfileService _profiles;
-	private readonly Mapper _mapper;
-
+	
 	public required string Handle { get; set; }
-	public required Models.Profile Prof { get; set; }
-	public required string Json { get; set; }
+	public required string DisplayName { get; set; }
+	public required string Description { get; set; }
+	public required Models.CustomField[] CustomFields { get; set; }
+	
+	private protected Models.Profile? Prof { get; set; }
+	
+	public int GetFollowerCount => Prof!.FollowersCollection.Count;
+	public int GetFollowingCount => Prof!.FollowingCollection.Count;
 
-	public Profile(IProfileService profiles, MappingConfigProvider mappingConfigs)
+
+	public Profile(IProfileService profiles)
 	{
 		_profiles = profiles;
-		_mapper = new Mapper(mappingConfigs.Profiles);
 	}
 
 	public async Task<IActionResult> OnGet(string handle)
@@ -32,9 +32,10 @@ public class Profile : PageModel
 			return NotFound();
 		Prof = profile;
 		Handle = handle;
+		DisplayName = profile.DisplayName;
+		Description = profile.Description;
+		CustomFields = profile.CustomFields;
 
-		var options = new JsonSerializerOptions { WriteIndented = true };
-		Json = JsonSerializer.Serialize(_mapper.Map<FullProfileDto>(Prof), options);
 
 		return Page();
 	}


### PR DESCRIPTION
This displays basic profile information on the profile page. I edited my profile in postgres directly to provide description and custom fields: 
<img width="563" alt="image" src="https://github.com/Letterbook/Letterbook/assets/891/d1d02616-9ea9-4e0b-9041-d8cc935619a1">

## Details
- I really do not want to expose the main `Prof` model to the template for reasons discussed in Discord. For posterity, the concern is about keeping an inventory of work done (database access, etc) outside the templates. The main model has a number of methods available that can do all sorts of things, and those should not be available to the template. I'm still new to dotnet / csharp, but the way I found to do this was by making the `Prof` field `private protected` and nullable; anything else I tried either still exposed that field to the template or gave me compiler warnings/errors.

## Related
Further things that could be useful here:
- how do I get a list of posts created by the user? I've looked through post the Posts and Timeline services, but neither has what looks like an appropriate method currently. My guess is this isn't implemented yet?
- how to get the server's url, to fill out the handle? right now it displays `@admin` but it should display `@admin@example.com` or whatever the host is.