### PR TITLE
Reduce integration test conflicts

### DIFF
--- a/Letterbook.Adapter.ActivityPub.IntegrationTests/ActivityPubClientCompositeTests.cs
+++ b/Letterbook.Adapter.ActivityPub.IntegrationTests/ActivityPubClientCompositeTests.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Letterbook.Core;
 using Letterbook.Core.Tests.Fakes;
 using Microsoft.Extensions.DependencyInjection;
@@ -7,7 +8,7 @@ using Xunit.Abstractions;
 
 namespace Letterbook.Adapter.ActivityPub.IntegrationTests;
 
-// These tests bypass the API (which mostly doesn't exist yet), and mock the database (because managing test data is 
+// These tests bypass the API (which mostly doesn't exist yet), and mock the database (because managing test data is
 // hard). Everything else is live. So, the end result is they send real federated messages using the real core logic
 // and AP client. The test data is entirely fabricated by the test, and we don't have to worry about our own
 // authentication.
@@ -56,6 +57,6 @@ public class ActivityPubClientCompositeTests : IClassFixture<HostFixture>
 
 		var profileService = scope.ServiceProvider.GetRequiredService<IProfileService>();
 
-		var result = await profileService.Follow((Guid)profile.Id!, remote);
+		var result = await profileService.As(Enumerable.Empty<Claim>()).Follow((Guid)profile.Id!, remote);
 	}
 }

--- a/Letterbook.Adapter.ActivityPub.IntegrationTests/HostFixture.cs
+++ b/Letterbook.Adapter.ActivityPub.IntegrationTests/HostFixture.cs
@@ -4,6 +4,7 @@ using Letterbook.Core;
 using Letterbook.Core.Adapters;
 using Letterbook.Core.Tests;
 using Letterbook.Core.Tests.Fakes;
+using Letterbook.Core.Tests.Mocks;
 using Letterbook.Core.Workers;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -66,7 +67,7 @@ public class HostFixture : WebApplicationFactory<Program>
 
 public class HostMocks : WithMocks
 {
-	public new Mock<HttpMessageHandler> HttpMessageHandlerMock => base.HttpMessageHandlerMock;
+	public new Mock<MockableMessageHandler> HttpMessageHandlerMock => base.HttpMessageHandlerMock;
 
 	public new IOptions<CoreOptions> CoreOptionsMock => base.CoreOptionsMock;
 

--- a/Letterbook.Adapter.ActivityPub.Test/MapperTests.cs
+++ b/Letterbook.Adapter.ActivityPub.Test/MapperTests.cs
@@ -1,15 +1,13 @@
-using System.Reflection;
 using ActivityPub.Types.AS;
 using ActivityPub.Types.AS.Collection;
-using ActivityPub.Types.AS.Extended.Actor;
 using ActivityPub.Types.AS.Extended.Object;
 using ActivityPub.Types.Conversion;
 using ActivityPub.Types.Util;
 using AutoMapper;
 using Letterbook.Adapter.ActivityPub.Types;
+using Letterbook.Core.Tests;
 using Letterbook.Core.Tests.Fakes;
 using Letterbook.Core.Tests.Fixtures;
-using Medo;
 using Xunit.Abstractions;
 
 namespace Letterbook.Adapter.ActivityPub.Test;

--- a/Letterbook.Api.IntegrationTests/Fixtures/HostFixture.cs
+++ b/Letterbook.Api.IntegrationTests/Fixtures/HostFixture.cs
@@ -1,53 +1,99 @@
+using System.Text.Json;
 using Letterbook.Adapter.Db;
 using Letterbook.Core;
 using Letterbook.Core.Models;
+using Letterbook.Core.Tests;
 using Letterbook.Core.Tests.Fakes;
 using Letterbook.Core.Tests.Fixtures;
+using Letterbook.Core.Workers;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Configuration;
+using Npgsql;
 using Xunit.Abstractions;
 using Xunit.Sdk;
+using RelationalContext = Letterbook.Adapter.Db.RelationalContext;
 
 namespace Letterbook.Api.IntegrationTests.Fixtures;
 
-public class HostFixture : WebApplicationFactory<Program>, IIntegrationTestData
+public class HostFixture<T> : WebApplicationFactory<Program>, IIntegrationTestData
 {
 	private readonly IMessageSink _sink;
 	private static readonly object _lock = new();
+
+	private string ConnectionString =
+		$"Database=letterbook_{typeof(T).Name};Server=localhost;Port=5432;User Id=letterbook;Password=letterbookpw;SSL Mode=Disable;Search Path=public;Include Error Detail=true";
 
 	public List<Profile> Profiles { get; set; } = new();
 	public List<Account> Accounts { get; set; } = new();
 	public Dictionary<Profile, List<Post>> Posts { get; set; } = new();
 	public int Records { get; set; }
 	public bool Deleted { get; set; }
-	public CoreOptions? Options;
+
+	public readonly CoreOptions Options;
+	public readonly DbOptions DbOptions;
 
 	public HostFixture(IMessageSink sink)
 	{
 		_sink = sink;
+		Options = new CoreOptions
+		{
+			DomainName = "localhost",
+			Scheme = "http",
+			Port = "5127"
+		};
 
+		InitializeTestData();
+	}
+
+	private void InitializeTestData()
+	{
 		lock (_lock)
 		{
 			_sink.OnMessage(new DiagnosticMessage("Bogus Seed: {0}", Init.WithSeed()));
-			Options = Services.GetRequiredService<IOptions<CoreOptions>>()?.Value;
 			this.InitTestData(Options);
 
-			using (var scope = Services.CreateScope())
-			{
-				var context = scope.ServiceProvider.GetRequiredService<RelationalContext>();
+			// using var scope = services.CreateScope();
+			// var context = scope.ServiceProvider.GetRequiredService<RelationalContext>();
+			var ds = new NpgsqlDataSourceBuilder(ConnectionString);
+			ds.EnableDynamicJson();
+			var context = new RelationalContext(new DbContextOptionsBuilder<RelationalContext>()
+				.UseNpgsql(ds.Build())
+				.Options);
 
-				Deleted = context.Database.EnsureDeleted();
-				context.Database.Migrate();
-				context.AddRange(Accounts);
-				context.AddRange(Profiles);
-				Records = context.SaveChanges();
-				context.AddRange(Posts.SelectMany(pair => pair.Value));
-				Records += context.SaveChanges();
-			}
-
-			_sink.OnMessage(new DiagnosticMessage($"Saved {Records} records"));
+			Deleted = context.Database.EnsureDeleted();
+			context.Database.Migrate();
+			context.AddRange(Accounts);
+			context.AddRange(Profiles);
+			Records = context.SaveChanges();
+			context.AddRange(Posts.SelectMany(pair => pair.Value));
+			Records += context.SaveChanges();
 		}
+	}
+
+	protected override void ConfigureWebHost(IWebHostBuilder builder)
+	{
+		// Override the db connection string (and potentially other config) so that we can have a db-per-class
+		// This eliminates a huge source of test data conflicts, and should make them parallelizable
+		// See https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-8.0#configuration-keys-and-values
+		var memConfig = new Dictionary<string, string>()
+		{
+			[DbOptions.ConfigKey + $":{nameof(DbOptions.ConnectionString)}"] = ConnectionString
+		};
+		var cfg = new ConfigurationBuilder().AddInMemoryCollection(memConfig).Build();
+
+		builder
+			.UseConfiguration(cfg)
+			.ConfigureServices(services =>
+			{
+				// SeedAdminWorker executes before we have a chance to create the test database
+				// So we just remove it
+				var seedDescriptor = services.SingleOrDefault(d => d.ImplementationType == typeof(WorkerScope<SeedAdminWorker>));
+
+				services.Remove(seedDescriptor);
+			});
+
+		base.ConfigureWebHost(builder);
 	}
 }

--- a/Letterbook.Api.IntegrationTests/PostsTests.cs
+++ b/Letterbook.Api.IntegrationTests/PostsTests.cs
@@ -17,10 +17,9 @@ using Profile = Letterbook.Core.Models.Profile;
 
 namespace Letterbook.Api.IntegrationTests;
 
-[Collection("Integration")]
-public class PostsTests : IClassFixture<HostFixture>
+public class PostsTests : IClassFixture<HostFixture<PostsTests>>
 {
-	private readonly HostFixture _host;
+	private readonly HostFixture<PostsTests> _host;
 	private readonly HttpClient _client;
 	private readonly List<Profile> _profiles;
 	private readonly FakePostDto _postDto;
@@ -29,7 +28,7 @@ public class PostsTests : IClassFixture<HostFixture>
 	private readonly Dictionary<Profile, List<Post>> _posts;
 	private readonly ContentTextComparer _contentTextComparer = new ContentTextComparer();
 
-	public PostsTests(HostFixture host)
+	public PostsTests(HostFixture<PostsTests> host)
 	{
 		_host = host;
 		_client = _host.Options == null

--- a/Letterbook.Api/Program.cs
+++ b/Letterbook.Api/Program.cs
@@ -13,15 +13,17 @@ public class Program
 {
 	public static void Main(string[] args)
 	{
-		// Pre initialize Serilog
-		Log.Logger = new LoggerConfiguration()
-			.MinimumLevel.Override("Microsoft", LogEventLevel.Information)
-			.Enrich.FromLogContext()
-			.Enrich.WithSpan()
-			.WriteTo.Console()
-			.CreateBootstrapLogger();
-
 		var builder = WebApplication.CreateBuilder(args);
+
+		// Pre initialize Serilog boostrap logger
+		if(builder.Environment.IsProduction())
+			Log.Logger = new LoggerConfiguration()
+				.MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+				.Enrich.FromLogContext()
+				.Enrich.WithSpan()
+				.WriteTo.Console()
+				.CreateBootstrapLogger();
+
 		var coreOptions = builder.Configuration.GetSection(CoreOptions.ConfigKey).Get<CoreOptions>()
 		                  ?? throw new ConfigException(nameof(CoreOptions));
 

--- a/Letterbook.Core.Tests/TestData.cs
+++ b/Letterbook.Core.Tests/TestData.cs
@@ -1,6 +1,6 @@
 using System.Reflection;
 
-namespace Letterbook.Adapter.ActivityPub.Test;
+namespace Letterbook.Core.Tests;
 
 public static class TestData
 {


### PR DESCRIPTION
Sets up (some, more to come) integration tests to run with a dedicated database per class, which eliminates the biggest source of conflicts and makes them more parallelizable.

## Details
- Override the config used in tests
- Set a unique database name, based on the test class
- Skip the bootstrap logger during tests
