### PR TITLE
enhancement(web): default register, login, logout

### DIFF
--- a/Letterbook.Api/DependencyInjectionExtensions.cs
+++ b/Letterbook.Api/DependencyInjectionExtensions.cs
@@ -85,6 +85,16 @@ public static class DependencyInjectionExtensions
 			}));
 	}
 
+	public static IdentityBuilder AddIdentity(this IServiceCollection services)
+	{
+		return services.AddIdentity<Account, IdentityRole<Guid>>(options =>
+			{
+				
+			})
+			.AddEntityFrameworkStores<RelationalContext>()
+			.AddDefaultTokenProviders();
+	}
+
 	public static IServiceCollection AddServices(this IServiceCollection services, ConfigurationManager configuration)
 	{
 		// Register options
@@ -122,8 +132,6 @@ public static class DependencyInjectionExtensions
 		services.AddSingleton<IActivityPubDocument, Document>();
 		services.AddDbAdapter(configuration.GetSection(DbOptions.ConfigKey));
 		services.AddDbContext<FeedsContext>();
-		services.AddIdentity<Account, IdentityRole<Guid>>()
-			.AddEntityFrameworkStores<RelationalContext>();
 		services.TryAddTypesModule();
 
 		// Register HTTP signature authentication services

--- a/Letterbook.Api/Program.cs
+++ b/Letterbook.Api/Program.cs
@@ -45,6 +45,7 @@ public class Program
 		builder.Services.AddHealthChecks();
 		builder.Services.AddActivityPubClient(builder.Configuration);
 		builder.Services.AddServices(builder.Configuration);
+		builder.Services.AddIdentity();
 
 		builder.WebHost.UseUrls(coreOptions.BaseUri().ToString());
 

--- a/Letterbook.Web/Areas/Identity/Pages/Account/Login.cshtml
+++ b/Letterbook.Web/Areas/Identity/Pages/Account/Login.cshtml
@@ -1,0 +1,85 @@
+﻿@page
+@model Letterbook.Web.Areas.Identity.Pages.Account.LoginModel
+
+@{
+    ViewData["Title"] = "Log in";
+}
+
+<h1>@ViewData["Title"]</h1>
+<div class="row">
+    <div class="col-md-4">
+        <section>
+            <form id="account" method="post">
+                <h2>Use a local account to log in.</h2>
+                <p>Loaded</p>
+                
+                <hr />
+                <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+                <div class="form-floating mb-3">
+                    <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
+                    <label asp-for="Input.Email" class="form-label">Email</label>
+                    <span asp-validation-for="Input.Email" class="text-danger"></span>
+                </div>
+                <div class="form-floating mb-3">
+                    <input asp-for="Input.Password" class="form-control" autocomplete="current-password" aria-required="true" placeholder="password" />
+                    <label asp-for="Input.Password" class="form-label">Password</label>
+                    <span asp-validation-for="Input.Password" class="text-danger"></span>
+                </div>
+                <div class="checkbox mb-3">
+                    <label asp-for="Input.RememberMe" class="form-label">
+                        <input class="form-check-input" asp-for="Input.RememberMe" />
+                        @Html.DisplayNameFor(m => m.Input.RememberMe)
+                    </label>
+                </div>
+                <div>
+                    <button id="login-submit" type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>
+                </div>
+                <div>
+                    <p>
+                        <a id="forgot-password" asp-page="./ForgotPassword">Forgot your password?</a>
+                    </p>
+                    <p>
+                        <a asp-page="./Register" asp-route-returnUrl="@Model.ReturnUrl">Register as a new user</a>
+                    </p>
+                    <p>
+                        <a id="resend-confirmation" asp-page="./ResendEmailConfirmation">Resend email confirmation</a>
+                    </p>
+                </div>
+            </form>
+        </section>
+    </div>
+    <div class="col-md-6 col-md-offset-2">
+        <section>
+            <h3>Use another service to log in.</h3>
+            <hr />
+            @{
+                if ((Model.ExternalLogins?.Count ?? 0) == 0)
+                {
+                    <div>
+                        <p>
+                            There are no external authentication services configured. See this <a href="https://go.microsoft.com/fwlink/?LinkID=532715">article
+                            about setting up this ASP.NET application to support logging in via external services</a>.
+                        </p>
+                    </div>
+                }
+                else
+                {
+                    <form id="external-account" asp-page="./ExternalLogin" asp-route-returnUrl="@Model.ReturnUrl" method="post" class="form-horizontal">
+                        <div>
+                            <p>
+                                @foreach (var provider in Model.ExternalLogins!)
+                                {
+                                    <button type="submit" class="btn btn-primary" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.DisplayName</button>
+                                }
+                            </p>
+                        </div>
+                    </form>
+                }
+            }
+        </section>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/Letterbook.Web/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/Letterbook.Web/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -1,0 +1,109 @@
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+using Letterbook.Core;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Letterbook.Web.Areas.Identity.Pages.Account
+{
+    public class LoginModel : PageModel
+    {
+        private readonly SignInManager<Models.Account> _signInManager;
+        private readonly UserManager<Models.Account> _userManager;
+        private readonly ILogger<LoginModel> _logger;
+
+        public required IList<AuthenticationScheme> ExternalLogins { get; set; } = null!;
+        public required string ReturnUrl { get; set; } = null!;
+
+        [BindProperty]
+        public required InputModel Input { get; set; } = null!;
+
+        [TempData]
+        public required string ErrorMessage { get; set; } = null!;
+
+        [SetsRequiredMembers]
+        public LoginModel(ILogger<LoginModel> logger, SignInManager<Models.Account> signInManager, UserManager<Models.Account> userManager)
+        {
+            _signInManager = signInManager;
+            _userManager = userManager;
+            _logger = logger;
+        }
+
+        public class InputModel
+        {
+            [Required]
+            [EmailAddress]
+            public required string Email { get; set; }
+
+            [Required]
+            [DataType(DataType.Password)]
+            public required string Password { get; set; }
+
+            [Display(Name = "Remember me?")]
+            public bool RememberMe { get; set; }
+        }
+
+        public async Task OnGetAsync(string? returnUrl = null)
+        {
+            if (!string.IsNullOrEmpty(ErrorMessage))
+            {
+                ModelState.AddModelError(string.Empty, ErrorMessage);
+            }
+
+            returnUrl ??= Url.Content("~/");
+
+            // Clear the existing external cookie to ensure a clean login process
+            await HttpContext.SignOutAsync(IdentityConstants.ExternalScheme);
+
+            ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
+
+            ReturnUrl = returnUrl;
+        }
+
+        public async Task<IActionResult> OnPostAsync(string? returnUrl = null)
+        {
+            returnUrl ??= Url.Content("~/");
+
+            ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
+
+            if (ModelState.IsValid)
+            {
+                // This is less than ideal, from a security perspective.
+                // It leaks whether an email address is in use.
+                var user = await _userManager.FindByEmailAsync(Input.Email);
+                if (user is null)
+                {
+	                ModelState.AddModelError(string.Empty, "Invalid login attempt.");
+	                return Page();
+                }
+                // This doesn't count login failures towards account lockout
+                // To enable password failures to trigger account lockout, set lockoutOnFailure: true
+                var result = await _signInManager.PasswordSignInAsync(user, Input.Password, Input.RememberMe, lockoutOnFailure: false);
+                if (result.Succeeded)
+                {
+                    _logger.LogInformation("User logged in.");
+                    return LocalRedirect(returnUrl);
+                }
+                if (result.RequiresTwoFactor)
+                {
+                    return RedirectToPage("./LoginWith2fa", new { ReturnUrl = returnUrl, RememberMe = Input.RememberMe });
+                }
+                if (result.IsLockedOut)
+                {
+                    _logger.LogWarning("User account locked out.");
+                    return RedirectToPage("./Lockout");
+                }
+                else
+                {
+                    ModelState.AddModelError(string.Empty, "Invalid login attempt.");
+                    return Page();
+                }
+            }
+
+            // If we got this far, something failed, redisplay form
+            return Page();
+        }
+    }
+}

--- a/Letterbook.Web/Areas/Identity/Pages/Account/Logout.cshtml
+++ b/Letterbook.Web/Areas/Identity/Pages/Account/Logout.cshtml
@@ -1,0 +1,21 @@
+﻿@page
+@model Letterbook.Web.Areas.Identity.Pages.Account.LogoutModel
+@{
+    ViewData["Title"] = "Log out";
+}
+
+<header>
+    <h1>@ViewData["Title"]</h1>
+    @{
+        if (User.Identity?.IsAuthenticated ?? false)
+        {
+            <form class="form-inline" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Page("/", new { area = "" })" method="post">
+                <button type="submit" class="nav-link btn btn-link text-dark">Click here to Logout</button>
+            </form>
+        }
+        else
+        {
+            <p>You have successfully logged out of the application.</p>
+        }
+    }
+</header>

--- a/Letterbook.Web/Areas/Identity/Pages/Account/Logout.cshtml.cs
+++ b/Letterbook.Web/Areas/Identity/Pages/Account/Logout.cshtml.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Letterbook.Web.Areas.Identity.Pages.Account
+{
+    public class LogoutModel : PageModel
+    {
+        private readonly SignInManager<Models.Account> _signInManager;
+        private readonly ILogger<LogoutModel> _logger;
+
+        public LogoutModel(SignInManager<Models.Account> signInManager, ILogger<LogoutModel> logger)
+        {
+            _signInManager = signInManager;
+            _logger = logger;
+        }
+
+        public async Task<IActionResult> OnPost(string returnUrl = null)
+        {
+            await _signInManager.SignOutAsync();
+            _logger.LogInformation("User logged out.");
+            if (returnUrl != null)
+            {
+                return LocalRedirect(returnUrl);
+            }
+            else
+            {
+                // This needs to be a redirect so that the browser performs a new
+                // request and the identity for the user gets updated.
+                return RedirectToPage();
+            }
+        }
+    }
+}

--- a/Letterbook.Web/Areas/Identity/Pages/Account/Register.cshtml
+++ b/Letterbook.Web/Areas/Identity/Pages/Account/Register.cshtml
@@ -1,0 +1,52 @@
+﻿@page
+@model Letterbook.Web.Areas.Identity.Pages.Account.RegisterModel
+@{
+    ViewData["Title"] = "Register";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<div class="row">
+    <div class="col-md-4">
+        <form id="registerForm" asp-route-returnUrl="@Model.ReturnUrl" method="post">
+            <h2>Create a new account.</h2>
+            <hr />
+            <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+            <div class="form-floating mb-3">
+                <input asp-for="Input.Handle" class="form-control" autocomplete="username" aria-required="true" placeholder="Your_name" />
+                <label asp-for="Input.Handle">Username</label>
+                <span asp-validation-for="Input.Handle" class="text-danger"></span>
+            </div>
+            <div class="form-floating mb-3">
+                <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
+                <label asp-for="Input.Email">Email</label>
+                <span asp-validation-for="Input.Email" class="text-danger"></span>
+            </div>
+            <div class="form-floating mb-3">
+                <input asp-for="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" placeholder="password" />
+                <label asp-for="Input.Password">Password</label>
+                <span asp-validation-for="Input.Password" class="text-danger"></span>
+            </div>
+            <div class="form-floating mb-3">
+                <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="password" />
+                <label asp-for="Input.ConfirmPassword">Confirm Password</label>
+                <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
+            </div>
+            <button id="registerSubmit" type="submit" class="w-100 btn btn-lg btn-primary">Register</button>
+        </form>
+    </div>
+    <div class="col-md-6 col-md-offset-2">
+        <section>
+            <h3>Server Info</h3>
+            <hr />
+            <div>
+                @* TODO *@
+                <p>TODO: Replace with server info and policies</p>
+            </div>
+        </section>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/Letterbook.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/Letterbook.Web/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -1,0 +1,163 @@
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Text.Encodings.Web;
+using Letterbook.Core;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace Letterbook.Web.Areas.Identity.Pages.Account
+{
+    public class RegisterModel : PageModel
+    {
+        private readonly SignInManager<Models.Account> _signInManager;
+        private readonly IAccountService _accounts;
+        private readonly UserManager<Models.Account> _userManager;
+        private readonly IUserStore<IdentityUser>? _userStore;
+        private readonly IUserEmailStore<IdentityUser>? _emailStore;
+        private readonly ILogger<RegisterModel> _logger;
+        private readonly IEmailSender? _emailSender;
+
+        [BindProperty]
+        public required InputModel Input { get; set; }
+        public required string ReturnUrl { get; set; }
+        public required IList<AuthenticationScheme> ExternalLogins { get; set; }
+
+        [SetsRequiredMembers]
+        public RegisterModel(ILogger<RegisterModel> logger, UserManager<Models.Account> userManager, SignInManager<Models.Account> signInManager, IAccountService accounts)
+        {
+	        _logger = logger;
+	        _userManager = userManager;
+	        _signInManager = signInManager;
+	        _accounts = accounts;
+
+	        Input = default!;
+	        ReturnUrl = default!;
+	        ExternalLogins = default!;
+        }
+
+        [SetsRequiredMembers]
+        protected RegisterModel(
+            ILogger<RegisterModel> logger,
+            UserManager<Models.Account> userManager,
+            SignInManager<Models.Account> signInManager,
+            IAccountService accounts,
+            IUserStore<IdentityUser> userStore,
+            IEmailSender emailSender) : this(logger, userManager, signInManager, accounts)
+        {
+            _userStore = userStore;
+            _emailStore = GetEmailStore();
+            _emailSender = emailSender;
+        }
+
+
+        public class InputModel
+        {
+            [Required]
+            [EmailAddress]
+            [Display(Name = "Email")]
+            public string Email { get; set; }
+
+            [Required]
+            [Display(Name = "Username")]
+            public string Handle { get; set; }
+
+            [Required]
+            [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
+            [DataType(DataType.Password)]
+            [Display(Name = "Password")]
+            public string Password { get; set; }
+
+            [DataType(DataType.Password)]
+            [Display(Name = "Confirm password")]
+            [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
+            public string ConfirmPassword { get; set; }
+        }
+
+
+        public async Task OnGetAsync(string returnUrl = null)
+        {
+            ReturnUrl = returnUrl;
+            ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
+        }
+
+        public async Task<IActionResult> OnPostAsync(string returnUrl = null)
+        {
+            returnUrl ??= Url.Content("~/");
+            ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
+            if (ModelState.IsValid)
+            {
+                var result = await _accounts.RegisterAccount(Input.Email, Input.Handle, Input.Password);
+                if (result.Succeeded)
+                {
+	                var user = await _userManager.FindByEmailAsync(Input.Email);
+                    _logger.LogInformation("User created a new account with password");
+
+                    if (_emailSender is not null)
+                    {
+	                    await SendConfirmationEmail(user, returnUrl);
+                    }
+
+                    if (_userManager.Options.SignIn.RequireConfirmedAccount)
+                    {
+                        return RedirectToPage("RegisterConfirmation", new { email = Input.Email, returnUrl = returnUrl });
+                    }
+                    else
+                    {
+                        await _signInManager.SignInAsync(user, isPersistent: false);
+                        return LocalRedirect(returnUrl);
+                    }
+                }
+                foreach (var error in result.Errors)
+                {
+                    ModelState.AddModelError(string.Empty, error.Description);
+                }
+            }
+
+            // If we got this far, something failed, redisplay form
+            return Page();
+        }
+
+        private async Task SendConfirmationEmail(Models.Account user, string returnUrl)
+        {
+	        var userId = await _userManager.GetUserIdAsync(user);
+	        var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+	        code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+	        var callbackUrl = Url.Page(
+		        "/Account/ConfirmEmail",
+		        pageHandler: null,
+		        values: new { area = "Identity", userId = userId, code = code, returnUrl = returnUrl },
+		        protocol: Request.Scheme);
+
+	        await _emailSender.SendEmailAsync(Input.Email, "Confirm your email",
+		        $"Please confirm your account by <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>clicking here</a>.");
+        }
+
+        private Models.Account CreateUser()
+        {
+            try
+            {
+                return Activator.CreateInstance<Models.Account>();
+            }
+            catch
+            {
+                throw new InvalidOperationException($"Can't create an instance of '{nameof(IdentityUser)}'. " +
+                    $"Ensure that '{nameof(IdentityUser)}' is not an abstract class and has a parameterless constructor, or alternatively " +
+                    $"override the register page in /Areas/Identity/Pages/Account/Register.cshtml");
+            }
+        }
+
+        private IUserEmailStore<IdentityUser> GetEmailStore()
+        {
+            if (!_userManager.SupportsUserEmail)
+            {
+                throw new NotSupportedException("The default UI requires a user store with email support.");
+            }
+            return (IUserEmailStore<IdentityUser>)_userStore;
+        }
+    }
+}

--- a/Letterbook.Web/Areas/Identity/Pages/Account/_ValidationScriptsPartial.cshtml
+++ b/Letterbook.Web/Areas/Identity/Pages/Account/_ValidationScriptsPartial.cshtml
@@ -1,0 +1,18 @@
+﻿<environment include="Development">
+    <script src="~/Identity/lib/jquery-validation/dist/jquery.validate.js"></script>
+    <script src="~/Identity/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.js"></script>
+</environment>
+<environment exclude="Development">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.17.0/jquery.validate.min.js"
+            asp-fallback-src="~/Identity/lib/jquery-validation/dist/jquery.validate.min.js"
+            asp-fallback-test="window.jQuery && window.jQuery.validator"
+            crossorigin="anonymous"
+            integrity="sha384-rZfj/ogBloos6wzLGpPkkOr/gpkBNLZ6b6yLy4o+ok+t/SAKlL5mvXLr0OXNi1Hp">
+    </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validation-unobtrusive/3.2.11/jquery.validate.unobtrusive.min.js"
+            asp-fallback-src="~/Identity/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js"
+            asp-fallback-test="window.jQuery && window.jQuery.validator && window.jQuery.validator.unobtrusive"
+            crossorigin="anonymous"
+            integrity="sha384-R3vNCHsZ+A2Lo3d5A6XNP7fdQkeswQWTIPfiYwSpEP3YV079R+93YzTeZRah7f/F">
+    </script>
+</environment>

--- a/Letterbook.Web/Areas/Identity/Pages/Account/_ViewImports.cshtml
+++ b/Letterbook.Web/Areas/Identity/Pages/Account/_ViewImports.cshtml
@@ -1,0 +1,4 @@
+@using Microsoft.AspNetCore.Identity
+@using Letterbook.Web.Areas.Identity
+@using Letterbook.Web.Areas.Identity.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/Letterbook.Web/Areas/Identity/Pages/Account/_ViewStart.cshtml
+++ b/Letterbook.Web/Areas/Identity/Pages/Account/_ViewStart.cshtml
@@ -1,0 +1,4 @@
+
+@{
+    Layout = "/Pages/Shared/_Layout.cshtml";
+}

--- a/Letterbook.Web/GlobalUsings.cs
+++ b/Letterbook.Web/GlobalUsings.cs
@@ -1,0 +1,3 @@
+// Global using directives
+
+global using Models = Letterbook.Core.Models;

--- a/Letterbook.Web/Pages/Profile.cshtml.cs
+++ b/Letterbook.Web/Pages/Profile.cshtml.cs
@@ -1,5 +1,4 @@
 ﻿using Letterbook.Core;
-using Models = Letterbook.Core.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Html;
@@ -11,14 +10,14 @@ public class Profile : PageModel
 {
 	private readonly IProfileService _profiles;
 	private readonly CoreOptions _options;
-	
+
 	public required string Handle { get; set; }
 	public required string DisplayName { get; set; }
 	public required HtmlString Description { get; set; }
 	public required Models.CustomField[] CustomFields { get; set; }
-	
+
 	private protected Models.Profile? Prof { get; set; }
-	
+
 	public int GetFollowerCount() => Prof!.FollowersCollection.Count;
 	public int GetFollowingCount() => Prof!.FollowingCollection.Count;
 
@@ -35,7 +34,7 @@ public class Profile : PageModel
 		if (found.FirstOrDefault() is not { } profile)
 			return NotFound();
 		Prof = profile;
-		
+
 		Handle = $"@{handle}@{_options.DomainName}";
 		DisplayName = profile.DisplayName;
 		Description = new HtmlString(profile.Description);

--- a/Letterbook.Web/Pages/Shared/_Layout.cshtml
+++ b/Letterbook.Web/Pages/Shared/_Layout.cshtml
@@ -26,6 +26,7 @@
                         <a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Privacy</a>
                     </li>
                 </ul>
+                <partial name="_LoginPartial"/>
             </div>
         </div>
     </nav>

--- a/Letterbook.Web/Pages/Shared/_LoginPartial.cshtml
+++ b/Letterbook.Web/Pages/Shared/_LoginPartial.cshtml
@@ -1,0 +1,27 @@
+@using Microsoft.AspNetCore.Identity
+
+@inject SignInManager<Models.Account> SignInManager
+@inject UserManager<Models.Account> UserManager
+
+<ul class="navbar-nav">
+@if (SignInManager.IsSignedIn(User))
+{
+    <li class="nav-item">
+        <a id="manage" class="nav-link text-dark" asp-area="Identity" asp-page="/Account/Manage/Index" title="Manage">Hello @UserManager.GetUserName(User)!</a>
+    </li>
+    <li class="nav-item">
+        <form id="logoutForm" class="form-inline" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Page("/Index", new { area = "" })">
+            <button id="logout" type="submit" class="nav-link btn btn-link text-dark border-0">Logout</button>
+        </form>
+    </li>
+}
+else
+{
+    <li class="nav-item">
+        <a class="nav-link text-dark" id="register" asp-area="Identity" asp-page="/Account/Register">Register</a>
+    </li>
+    <li class="nav-item">
+        <a class="nav-link text-dark" id="login" asp-area="Identity" asp-page="/Account/Login">Login</a>
+    </li>
+}
+</ul>

--- a/Letterbook.Web/Program.cs
+++ b/Letterbook.Web/Program.cs
@@ -4,6 +4,7 @@ using Letterbook.Api.Swagger;
 using Letterbook.Core;
 using Letterbook.Core.Exceptions;
 using Letterbook.Core.Extensions;
+using Microsoft.AspNetCore.Identity;
 using Serilog;
 using Serilog.Enrichers.Span;
 using Serilog.Events;
@@ -41,6 +42,14 @@ public class Program
 		builder.Services.AddHealthChecks();
 		builder.Services.AddActivityPubClient(builder.Configuration);
 		builder.Services.AddServices(builder.Configuration);
+		builder.Services.AddIdentity()
+			// Aspnet Core Identity includes a default UI, which provides basic account management.
+			// This includes register, login, logout, and maintenance views.
+			// However, it only seems to work well for fairly simple (single project) apps.  It also looks extremely Microsoft.
+			// We likely don't want to use it long term, but it's nice for the moment.
+			//
+			// We can work around some of the issues by overriding pages under Areas/IdentityPages/Account
+			.AddDefaultUI();
 		builder.Services.AddRazorPages();
 
 		builder.WebHost.UseUrls(coreOptions.BaseUri().ToString());


### PR DESCRIPTION
Adds default(ish) account registration, login, and logout pages from Aspnet Identity, and (actually) default account maintenance pages, to allow managing account data like change email and password resets.

The default UI is not one that we'll want to keep long term, but I think it will be helpful as a starting point, and just during development.

![image](https://github.com/Letterbook/Letterbook/assets/8325540/a944a3a2-58de-4dbe-8052-60ec568f3030)


## Details
- Use identity default UI via `AddDefaultUI()` builder method
- Override a handful of basic pages so they'll actually work
  - Scaffolding the pages is basically impossible in app where the dbcontext is in another project than the mvc app.
  - Many of the unscaffolded defaults don't actually work
