### PR TITLE
add FeedsDatabase to Web app settings

### DIFF
--- a/Letterbook.Web/appsettings.Development.json
+++ b/Letterbook.Web/appsettings.Development.json
@@ -13,6 +13,14 @@
     "Database": "letterbook",
     "ConnectionString": null
   },
+  "Letterbook.FeedsDatabase": {
+    "Host": "localhost",
+    "Port": "5432",
+    "Username": "letterbook",
+    "Password": "letterbookpw",
+    "Database": "letterbook_feeds",
+    "ConnectionString": null
+  },
   "Serilog": {
     "Using": [
       "Serilog.Sinks.Console",


### PR DESCRIPTION
 Adds the `Letterbook.FeedsDatabase` required config option to the web app's development settings. The server will error if this is not present