### PR TITLE
Internals/Log application startup

### DIFF
--- a/Letterbook.Core/Extensions/DependencyInjection.cs
+++ b/Letterbook.Core/Extensions/DependencyInjection.cs
@@ -32,7 +32,8 @@ public static class DependencyInjection
 			.AddSingleton<IHostSigningKeyProvider, DevelopmentHostSigningKeyProvider>();
 
 		// Register service workers
-		services.AddScopedService<SeedAdminWorker>();
+		services.AddScopedService<SeedAdminWorker>()
+			.AddHostedService<HostLifetimeWorker>();
 
 		return services;
 	}

--- a/Letterbook.Core/Workers/HostLifetimeWorker.cs
+++ b/Letterbook.Core/Workers/HostLifetimeWorker.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Letterbook.Core.Workers;
+
+public class HostLifetimeWorker : IHostedService
+{
+	private readonly ILogger<HostLifetimeWorker> _logger;
+	private readonly IHostApplicationLifetime _appLifetime;
+	private readonly IServer _server;
+
+	public HostLifetimeWorker(ILogger<HostLifetimeWorker> logger, IHostApplicationLifetime appLifetime, IServer server)
+	{
+		_logger = logger;
+		_appLifetime = appLifetime;
+		_server = server;
+	}
+
+	public Task StartAsync(CancellationToken cancellationToken)
+	{
+		_appLifetime.ApplicationStarted.Register(OnStarted);
+		_appLifetime.ApplicationStopping.Register(OnStopping);
+		_appLifetime.ApplicationStopped.Register(OnStopped);
+
+		return Task.CompletedTask;
+	}
+
+	private void OnStopped() => _logger.LogInformation("Application stopped");
+
+	private void OnStopping() => _logger.LogInformation("Application stop scheduled");
+
+	private void OnStarted()
+	{
+		_logger.LogInformation("Application started");
+
+		if (_server.Features.Get<IServerAddressesFeature>() is not { } feature)
+		{
+			_logger.LogWarning("Couldn't identity any listening address");
+			return;
+		}
+
+		foreach (var address in feature.Addresses)
+		{
+			_logger.LogInformation("Listening on {Address}", address);
+		}
+	}
+
+	public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}


### PR DESCRIPTION
Mainly a quality of life enhancement, so we know when the server is up and listening.


## Details
- Uses a hosted service to register listeners on application lifetime events
- And logs them

Typical application startup now looks like this
```log
/home/jenni/source/Letterbook/Letterbook/bin/Debug/net8.0/Letterbook 
[14:11:56 INF] Configured endpoint delivery-worker, Consumer: Letterbook.Workers.Consumers.DeliveryWorker
[14:11:56 INF] Configured endpoint timeline, Consumer: Letterbook.Workers.Consumers.TimelineConsumer
[14:11:58 DBG] Found accounts, skipping seed
[14:11:58 INF] Bus started: loopback://localhost/
[14:11:58 INF] Application started
[14:11:58 INF] Listening on http://localhost:5127

```