### PR TITLE
Fix/audience

### DIFF
--- a/Letterbook.Adapter.ActivityPub/Mappers/AstMapper.cs
+++ b/Letterbook.Adapter.ActivityPub/Mappers/AstMapper.cs
@@ -44,6 +44,7 @@ public static class AstMapper
 			.ForMember(dest => dest.OwnedBy, opt => opt.Ignore())
 			.ForMember(dest => dest.Accessors, opt => opt.Ignore())
 			.ForMember(dest => dest.Audiences, opt => opt.Ignore())
+			.ForMember(dest => dest.Headlining, opt => opt.Ignore())
 			.ForMember(dest => dest.FollowersCollection, opt => opt.Ignore())
 			.ForMember(dest => dest.FollowingCollection, opt => opt.Ignore())
 			.ForMember(dest => dest.FediId, opt => opt.MapFrom(src => src.Id))

--- a/Letterbook.Adapter.Db/EntityConfigs/ConfigureAudience.cs
+++ b/Letterbook.Adapter.Db/EntityConfigs/ConfigureAudience.cs
@@ -11,6 +11,7 @@ public class ConfigureAudience : IEntityTypeConfiguration<Models.Audience>
 		builder.HasMany<Models.Profile>(audience => audience.Members)
 			.WithMany(profile => profile.Audiences)
 			.UsingEntity("AudienceProfileMembers");
-		builder.HasOne<Models.Profile>(audience => audience.Source);
+		builder.HasOne<Models.Profile>(audience => audience.Source)
+			.WithMany(profile => profile.Headlining);
 	}
 }

--- a/Letterbook.Adapter.Db/Migrations/RelationalContextModelSnapshot.cs
+++ b/Letterbook.Adapter.Db/Migrations/RelationalContextModelSnapshot.cs
@@ -154,7 +154,7 @@ namespace Letterbook.Adapter.Db.Migrations
                     b.Property<Guid>("Id")
                         .HasColumnType("uuid");
 
-                    b.Property<DateTime>("Date")
+                    b.Property<DateTimeOffset>("Date")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid>("FollowerId")
@@ -622,7 +622,7 @@ namespace Letterbook.Adapter.Db.Migrations
             modelBuilder.Entity("Letterbook.Core.Models.Audience", b =>
                 {
                     b.HasOne("Letterbook.Core.Models.Profile", "Source")
-                        .WithMany()
+                        .WithMany("Leading")
                         .HasForeignKey("SourceId");
 
                     b.Navigation("Source");
@@ -868,6 +868,8 @@ namespace Letterbook.Adapter.Db.Migrations
                     b.Navigation("FollowingCollection");
 
                     b.Navigation("Keys");
+
+                    b.Navigation("Leading");
                 });
 
             modelBuilder.Entity("Letterbook.Core.Models.ThreadContext", b =>

--- a/Letterbook.Core/Extensions/CollectionExtensions.cs
+++ b/Letterbook.Core/Extensions/CollectionExtensions.cs
@@ -6,8 +6,12 @@ public static class CollectionExtensions
 	/// Uses IEquatable comparisons to return a new Collection which has items that are equivalent to the replacement collection,
 	/// but reusing any equivalent objects from the source collection.
 	///
-	/// This ensures that values are added and removed correctly, while preserving the reference equality for the source values.
+	/// The resulting collection is the same size and has the same values as the replacement, but retains reference equality to the
+	/// source, where there was overlap.
 	/// </summary>
+	/// <remarks>
+	/// This ensures that values are added and removed correctly, while preserving the reference equality for the source values.
+	/// </remarks>
 	/// <param name="source"></param>
 	/// <param name="replacement"></param>
 	/// <typeparam name="T"></typeparam>
@@ -17,6 +21,27 @@ public static class CollectionExtensions
 		var result = source.ToHashSet();
 		result.UnionWith(replacement);
 		result.IntersectWith(replacement);
+
+		return result;
+	}
+
+	/// <summary>
+	/// Uses IEquatable comparisons to return a new Collection which is equivalent to the source collection, but has intersecting
+	/// members taken from the replacement collection.
+	///
+	/// The resulting collection is the same size and has the same values as the source, but has reference equality to the
+	/// replacement, where there was overlap.
+	/// </summary>
+	/// <remarks>
+	/// This ensures that values are added and removed correctly, while preserving the reference equality for the source values.
+	/// </remarks>
+	/// <param name="source"></param>
+	/// <param name="from"></param>
+	public static ICollection<T> ReplaceFrom<T>(this ICollection<T> source, ICollection<T> from)
+	{
+		var result = from.ToHashSet();
+		result.IntersectWith(source);
+		result.UnionWith(source);
 
 		return result;
 	}

--- a/Letterbook.Core/Models/Profile.cs
+++ b/Letterbook.Core/Models/Profile.cs
@@ -84,6 +84,7 @@ public class Profile : IFederatedActor, IEquatable<Profile>
 	public Account? OwnedBy { get; set; }
 	public ICollection<ProfileClaims> Accessors { get; set; } = new HashSet<ProfileClaims>();
 	public ActivityActorType Type { get; set; }
+	public ICollection<Audience> Headlining { get; set; } = new HashSet<Audience>();
 	public ICollection<Audience> Audiences { get; set; } = new HashSet<Audience>();
 	public IList<FollowerRelation> FollowersCollection { get; set; } = new List<FollowerRelation>();
 	public IList<FollowerRelation> FollowingCollection { get; set; } = new List<FollowerRelation>();

--- a/Letterbook.Core/Models/Profile.cs
+++ b/Letterbook.Core/Models/Profile.cs
@@ -182,6 +182,7 @@ public class Profile : IFederatedActor, IEquatable<Profile>
 			DisplayName = handle,
 		};
 		profile.Audiences.Add(Audience.FromMention(profile));
+		profile.Headlining.Add(Audience.Followers(profile));
 		return profile;
 	}
 


### PR DESCRIPTION
Adds a Headlining audience navigation on Profile. This is the reciprocal of the Audiences property.

## Details
- Allows us to query for the Audiences that are controlled by a Profile, not just the ones the profile is a member of
- Fixed some tests
- Allows us to create the followers Audience when a profile is created, not just incidentally the first time it's followed.
- The navigation and foreign keys already existed, this just creates a property to represent it in code. So, it updates the model snapshot, but doesn't actually require a migration.
