### PR TITLE
Fix/httpsig

### DIFF
--- a/Letterbook.Api/Constants.cs
+++ b/Letterbook.Api/Constants.cs
@@ -3,4 +3,5 @@ namespace Letterbook.Api;
 public static class Constants
 {
 	public const string ApiPolicy = "Api";
+	public const string ActivityPubPolicy = "ActivityPub";
 }

--- a/Letterbook.Api/Controllers/ActivityPub/ActorController.cs
+++ b/Letterbook.Api/Controllers/ActivityPub/ActorController.cs
@@ -29,7 +29,7 @@ namespace Letterbook.Api.Controllers.ActivityPub;
 [Consumes("application/ld+json",
 	"application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"",
 	"application/activity+json")]
-[Authorize(policy: "ActivityPub")]
+[Authorize(policy: Constants.ActivityPubPolicy)]
 public class ActorController : ControllerBase
 {
 	private readonly ILogger<ActorController> _logger;
@@ -51,6 +51,7 @@ public class ActorController : ControllerBase
 
 	[HttpGet]
 	[Route("{id}")]
+	[AllowAnonymous]
 	public async Task<IActionResult> GetActor(string id)
 	{
 		if (!Id.TryAsUuid7(id, out var uuid))

--- a/Letterbook.Api/DependencyInjectionExtensions.cs
+++ b/Letterbook.Api/DependencyInjectionExtensions.cs
@@ -131,6 +131,12 @@ public static class DependencyInjectionExtensions
 		{
 			policy.RequireAuthenticatedUser();
 		});
+
+		options.AddPolicy(Constants.ActivityPubPolicy, policy =>
+		{
+			policy.RequireAuthenticatedUser();
+			policy.AddAuthenticationSchemes(HttpSignatureAuthenticationDefaults.Scheme);
+		});
 		return options;
 	}
 
@@ -198,15 +204,6 @@ public static class DependencyInjectionExtensions
 				options.RequireHttpsMetadata = false;
 			})
 			.AddHttpSignature();
-
-		services.AddAuthorization(opts =>
-		{
-			opts.AddPolicy("ActivityPub", static policy =>
-			{
-				policy.RequireAuthenticatedUser();
-				policy.AddAuthenticationSchemes(HttpSignatureAuthenticationDefaults.Scheme);
-			});
-		});
 
 		return services;
 	}

--- a/Letterbook.Dashboards/Grafana/provisioning/dashboards/definitions/operations/trace-detail.json
+++ b/Letterbook.Dashboards/Grafana/provisioning/dashboards/definitions/operations/trace-detail.json
@@ -1,0 +1,251 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "loki",
+          "uid": "P8E80F9AEF21F6940"
+        },
+        "enable": false,
+        "expr": "{app=\"letterbook\"} |= `` | json | TraceId = `$TraceID`",
+        "hide": false,
+        "iconColor": "yellow",
+        "instant": false,
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Correlated logs and spans for a single trace",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 20,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": false,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "pluginVersion": "11.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "editorMode": "builder",
+          "expr": "{app=\"letterbook\"} |= `` | json | TraceId = `$TraceID`",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs",
+      "transformations": [
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "json",
+            "jsonPaths": [
+              {
+                "alias": "message",
+                "path": "Message"
+              }
+            ],
+            "source": "labels"
+          }
+        }
+      ],
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "tempo"
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 1,
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "limit": 20,
+          "query": "$TraceID",
+          "queryType": "traceql",
+          "refId": "A",
+          "tableType": "traces"
+        }
+      ],
+      "title": "New Panel",
+      "type": "traces"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "topk(20, rate(pg_stat_user_tables_seq_scan[$__rate_interval]))",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Top 20 tables Seq Scan",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "2c65228b1272d3672f01102295b1f767",
+          "value": "2c65228b1272d3672f01102295b1f767"
+        },
+        "hide": 0,
+        "name": "TraceID",
+        "options": [
+          {
+            "selected": true,
+            "text": "2c65228b1272d3672f01102295b1f767",
+            "value": "2c65228b1272d3672f01102295b1f767"
+          }
+        ],
+        "query": "2c65228b1272d3672f01102295b1f767",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-2d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Trace Detail",
+  "uid": "fdrsk9dluncaoc",
+  "version": 3,
+  "weekStart": ""
+}

--- a/Letterbook/DependencyInjection.cs
+++ b/Letterbook/DependencyInjection.cs
@@ -1,6 +1,22 @@
-﻿
+﻿using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
 namespace Letterbook;
 
 public static class DependencyInjection
 {
+	public static OpenTelemetryBuilder AddAspnetTelemetry(this OpenTelemetryBuilder telemetry)
+	{
+		return telemetry.ConfigureResource(resource => { resource.AddService("Letterbook"); })
+			.WithMetrics(metrics =>
+			{
+				metrics.AddAspNetCoreInstrumentation();
+			})
+			.WithTracing(tracing =>
+			{
+				tracing.AddAspNetCoreInstrumentation();
+			});
+	}
 }

--- a/Letterbook/Program.cs
+++ b/Letterbook/Program.cs
@@ -3,6 +3,7 @@ using Letterbook.Adapter.ActivityPub;
 using Letterbook.Adapter.Db;
 using Letterbook.Adapter.TimescaleFeeds;
 using Letterbook.Api;
+using Letterbook.Api.Authentication.HttpSignature.DependencyInjection;
 using Letterbook.Api.Swagger;
 using Letterbook.AspNet;
 using Letterbook.Core.Extensions;
@@ -44,6 +45,8 @@ public class Program
 		);
 
 		builder.Services.AddOpenTelemetry()
+			.AddAspnetTelemetry()
+			.AddWorkerTelemetry()
 			.AddDbTelemetry()
 			.AddClientTelemetry()
 			.AddTelemetryExporters();
@@ -59,7 +62,6 @@ public class Program
 			.AddEntityFrameworkStores<RelationalContext>()
 			.AddDefaultTokenProviders()
 			.AddDefaultUI();
-		builder.Services.AddAuthentication("Test");
 		builder.Services.AddRazorPages()
 			.AddApplicationPart(Assembly.GetAssembly(typeof(Web.Program))!);
 		builder.Services.AddAuthorization(options =>
@@ -102,6 +104,7 @@ public class Program
 		app.MapPrometheusScrapingEndpoint();
 		app.UseWebFingerScoped();
 
+		app.UseHttpSignatureVerification();
 		app.UseAuthentication();
 		app.UseAuthorization();
 		app.UseWhen(ProfileIdentityPaths, applicationBuilder =>
@@ -121,11 +124,11 @@ public class Program
 
 		static bool ProfileIdentityPaths(HttpContext context)
 		{
-			return !context.Request.Path.StartsWithSegments("/Identity/")
+			return !context.Request.Path.StartsWithSegments("/Identity")
 			       // TODO: prefix with /ap/v1
 			       // Need to use url generators integrated with routing, instead of just a bunch of magic strings
-			       && !context.Request.Path.StartsWithSegments("/actor/")
-			       && !context.Request.Path.StartsWithSegments("/object/");
+			       && !context.Request.Path.StartsWithSegments("/actor")
+			       && !context.Request.Path.StartsWithSegments("/object");
 		}
 	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,8 +72,10 @@ services:
     
   tempo:
     container_name: tempo
-    image: grafana/tempo:2.5.0
+    image: &tempo-image grafana/tempo:2.5.0
     command: [ "-config.file=/etc/tempo.yaml" ]
+    depends_on:
+      - tempo-init
     volumes:
       - ./Letterbook.Dashboards/Tempo/tempo.yaml:/etc/tempo.yaml
       - letterbook_tempo_data:/tmp/tempo
@@ -81,6 +83,16 @@ services:
       - "9095:9095" # tempo grpc
       - "4317:4317"  # otlp grpc
     restart: unless-stopped
+
+  tempo-init:
+    image: *tempo-image
+    user: root
+    entrypoint:
+      - "chown"
+      - "10001:10001"
+      - "/var/tempo"
+    volumes:
+      - letterbook_tempo_data:/var/tempo
 
   db_metrics_exporter:
     container_name: metrics_exporter


### PR DESCRIPTION
Fix Http signature validation in the monolith

## Details
- `ProfileIdentityMiddleware` was triggering on AP paths
- This caused LB to respond with 401 to every signed request
- Also fixes the tempo docker service and adds a debugging-oriented dashboard

The purpose of that middleware is to hydrate the current live profile claims, per-request.

## Related
- closes #284 
