### PR TITLE
fix signatures for mastodon

### DIFF
--- a/Letterbook.Adapter.ActivityPub/Signatures/ClientHandler.cs
+++ b/Letterbook.Adapter.ActivityPub/Signatures/ClientHandler.cs
@@ -26,7 +26,7 @@ public class ClientHandler : DelegatingHandler
 				new HttpRequestOptionsKey<IEnumerable<Models.SigningKey>>(IClientSigner.SigningKeysOptionsId),
 				out IEnumerable<Models.SigningKey>? keys))
 		{
-			_logger.LogWarning("Can's sign request because no keys were available");
+			_logger.LogWarning("Can't sign request because no keys were available");
 			_logger.LogDebug("Couldn't sign request to {Destination}", request.RequestUri);
 			return base.SendAsync(request, cancellationToken);
 		}

--- a/Letterbook.Core/Models/Profile.cs
+++ b/Letterbook.Core/Models/Profile.cs
@@ -57,9 +57,9 @@ public class Profile : IFederatedActor, IEquatable<Profile>
 		SharedInbox = builder.Uri;
 
 		builder.Path = basePath;
-		builder.Fragment = "public_keys/0";
+		builder.Fragment = "key-0";
 		Keys.Add(SigningKey.Rsa(0, builder.Uri));
-		builder.Fragment = "public_keys/1";
+		builder.Fragment = "key-1";
 		Keys.Add(SigningKey.EcDsa(1, builder.Uri));
 	}
 

--- a/Letterbook.Core/ProfileService.cs
+++ b/Letterbook.Core/ProfileService.cs
@@ -186,7 +186,7 @@ public class ProfileService : IProfileService, IAuthzProfileService
 	public async Task<Profile?> LookupProfile(Uuid7 profileId, Uuid7? relatedProfile)
 	{
 		var query = _profiles.SingleProfile(profileId);
-		query = relatedProfile.HasValue ? _profiles.WithRelation(query, relatedProfile.Value) : query;
+		query = relatedProfile.HasValue ? _profiles.WithRelation(query, relatedProfile.Value) : query.Include(p => p.Keys);
 
 		return await query.FirstOrDefaultAsync();
 	}


### PR DESCRIPTION
Apparently they cannot handle slashes in the fragment. I feel like I might have discovered that once before?

> [!TIP]
> You might want to drop and recreate your local database, or at least create new profiles to test federation after this fix

To get activities from existing profiles to federate, you'll have to change the fediId on the signing keys.

## Details
- Mastodon just doesn't validate signatures when the key has a slash `/` in the fragment
- It is completely valid and acceptable to have slashes in the fragment portion of a URL
- c'est la mastodon, I guess
