### PR TITLE
f/add playwright testing project to main #205

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -64,7 +64,7 @@ jobs:
         run: pwsh Letterbook.Web.Tests/bin/Release/net8.0/playwright.ps1 install firefox
 
       - name: E2E Test
-        run: BROWSER=firefox dotnet test Letterbook.Web.Tests.E2E --no-build
+        run: BROWSER=firefox dotnet test Letterbook.Web.Tests.E2E --no-build --configuration Release
         
       - name: Save test crash report
         if: failure()

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'main'
+      - "main"
   pull_request:
     types:
       - opened
@@ -12,53 +12,71 @@ on:
       - synchronize
       - ready_for_review
     branches:
-      - 'main'
+      - "main"
 
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
       NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
-      
+
     steps:
       - uses: actions/checkout@v4
-        
+
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
-      
+
       - name: Package Cache
         id: package-cache
         uses: actions/cache@v4
         with:
           path: ${{env.NUGET_PACKAGES}}
           key: "${{ runner.os }}-nuget-${{ hashFiles('Directory.Packages.props') }}"
-      
+
       - name: Restore Packages
         if: steps.package-cache.outputs.cache-hit != 'true'
         run: dotnet restore
-      
+
       - name: Restore Tools
         run: dotnet tool restore
-      
+
       - name: Build
         run: dotnet build Letterbook.sln --configuration Release
-      
+
       - name: Test
         run: dotnet test Letterbook.UnitTests.slnf --configuration Release --logger GitHubActions --blame-crash --no-build
-        
+
+      - name: Run docker-compose
+        uses: hoverkraft-tech/compose-action@v2.0.1
+
+      - name: Seed database
+        run:
+          dotnet ef database update --project Letterbook.Adapter.Db/Letterbook.Adapter.Db.csproj &&
+          dotnet ef database update --project Letterbook.Adapter.TimescaleFeeds/Letterbook.Adapter.TimescaleFeeds.csproj &&
+          dotnet user-secrets set "HostSecret" "$(openssl rand -base64 32)" --project Letterbook
+
+      - name: Start server
+        run: dotnet run --project Letterbook.Web &
+
+      - name: Install Playwright Browsers
+        run: pwsh Letterbook.Web.Tests/bin/Release/net8.0/playwright.ps1 install firefox
+
+      - name: E2E Test
+        run: BROWSER=firefox dotnet test Letterbook.Web.Tests.E2E --no-build --configuration Release
+
       - name: Save test crash report
         if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: TestResults
-          path: '**/TestResults/'
-      
+          path: "**/TestResults/"
+
       - name: Check Relational Migrations
         run: dotnet ef migrations has-pending-model-changes
         working-directory: Letterbook.Adapter.Db/
-        
+
       - name: Check Feeds Migrations
         run: dotnet ef migrations has-pending-model-changes
         working-directory: Letterbook.Adapter.TimescaleFeeds/
@@ -70,7 +88,7 @@ jobs:
           dotnet run --AppTasks=prerender --BaseUrl "${{env.custom_domain}}"
         env:
           custom_domain: "letterbook.com"
-      
+
       - name: Check Generated Files
         run: |
           CHANGED=$(git status --porcelain -uno)

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -64,10 +64,9 @@ jobs:
         run: pwsh Letterbook.Web.Tests/bin/Release/net8.0/playwright.ps1 install firefox
 
       - name: E2E Test
-        run: dotnet test Letterbook.Web.Tests.E2E --no-build
+        run: dotnet test Letterbook.Web.Tests.E2E --no-build --configuration Release
         env:
           BROWSER: firefox
-          DOTNET_ENVIRONMENT: Release
         
       - name: Save test crash report
         if: failure()

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -64,7 +64,7 @@ jobs:
         run: pwsh Letterbook.Web.Tests/bin/Release/net8.0/playwright.ps1 install firefox
 
       - name: E2E Test
-        run: BROWSER=firefox dotnet test Letterbook.Web.Tests.E2E --no-build --configuration Release
+        run: BROWSER=firefox dotnet test Letterbook.Web.Tests.E2E --no-build
 
       - name: Save test crash report
         if: failure()

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -47,26 +47,6 @@ jobs:
       
       - name: Test
         run: dotnet test Letterbook.UnitTests.slnf --configuration Release --logger GitHubActions --blame-crash --no-build
-
-      - name: Run docker-compose
-        uses: hoverkraft-tech/compose-action@v2.0.1
-
-      - name: Seed database
-        run:
-          dotnet ef database update --project Letterbook.Adapter.Db/Letterbook.Adapter.Db.csproj &&
-          dotnet ef database update --project Letterbook.Adapter.TimescaleFeeds/Letterbook.Adapter.TimescaleFeeds.csproj &&
-          dotnet user-secrets set "HostSecret" "$(openssl rand -base64 32)" --project Letterbook
-
-      - name: Start server
-        run: dotnet run --project Letterbook.Web &
-
-      - name: Install Playwright Browsers
-        run: pwsh Letterbook.Web.Tests/bin/Release/net8.0/playwright.ps1 install firefox
-
-      - name: E2E Test
-        run: dotnet test Letterbook.Web.Tests.E2E --no-build --configuration Release
-        env:
-          BROWSER: firefox
         
       - name: Save test crash report
         if: failure()
@@ -100,3 +80,60 @@ jobs:
             exit 1
           fi
         shell: bash
+        
+  end-to-end-test:
+    runs-on: ubuntu-latest
+    env:
+      NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Package Cache
+        id: package-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{env.NUGET_PACKAGES}}
+          key: "${{ runner.os }}-nuget-${{ hashFiles('Directory.Packages.props') }}"
+
+      - name: Restore Packages
+        if: steps.package-cache.outputs.cache-hit != 'true'
+        run: dotnet restore
+
+      - name: Restore Tools
+        run: dotnet tool restore
+
+      - name: Build
+        run: dotnet build Letterbook.sln --configuration Release
+
+      - name: Run docker-compose
+        uses: hoverkraft-tech/compose-action@v2.0.1
+
+      - name: Seed database
+        run:
+          dotnet ef database update --project Letterbook.Adapter.Db/Letterbook.Adapter.Db.csproj &&
+          dotnet ef database update --project Letterbook.Adapter.TimescaleFeeds/Letterbook.Adapter.TimescaleFeeds.csproj &&
+          dotnet user-secrets set "HostSecret" "$(openssl rand -base64 32)" --project Letterbook
+
+      - name: Start server
+        run: dotnet run --project Letterbook.Web &
+
+      - name: Install Playwright Browsers
+        run: pwsh Letterbook.Web.Tests/bin/Release/net8.0/playwright.ps1 install firefox
+
+      - name: E2E Test
+        run: dotnet test Letterbook.Web.Tests.E2E --no-build --configuration Release
+        env:
+          BROWSER: firefox
+
+      - name: Save test crash report
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: TestResults
+          path: '**/TestResults/'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - "main"
+      - 'main'
   pull_request:
     types:
       - opened
@@ -12,39 +12,39 @@ on:
       - synchronize
       - ready_for_review
     branches:
-      - "main"
+      - 'main'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
       NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
-
+      
     steps:
       - uses: actions/checkout@v4
-
+        
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
-
+      
       - name: Package Cache
         id: package-cache
         uses: actions/cache@v4
         with:
           path: ${{env.NUGET_PACKAGES}}
           key: "${{ runner.os }}-nuget-${{ hashFiles('Directory.Packages.props') }}"
-
+      
       - name: Restore Packages
         if: steps.package-cache.outputs.cache-hit != 'true'
         run: dotnet restore
-
+      
       - name: Restore Tools
         run: dotnet tool restore
-
+      
       - name: Build
         run: dotnet build Letterbook.sln --configuration Release
-
+      
       - name: Test
         run: dotnet test Letterbook.UnitTests.slnf --configuration Release --logger GitHubActions --blame-crash --no-build
 
@@ -65,18 +65,18 @@ jobs:
 
       - name: E2E Test
         run: BROWSER=firefox dotnet test Letterbook.Web.Tests.E2E --no-build
-
+        
       - name: Save test crash report
         if: failure()
         uses: actions/upload-artifact@v3
         with:
           name: TestResults
-          path: "**/TestResults/"
-
+          path: '**/TestResults/'
+      
       - name: Check Relational Migrations
         run: dotnet ef migrations has-pending-model-changes
         working-directory: Letterbook.Adapter.Db/
-
+        
       - name: Check Feeds Migrations
         run: dotnet ef migrations has-pending-model-changes
         working-directory: Letterbook.Adapter.TimescaleFeeds/
@@ -88,7 +88,7 @@ jobs:
           dotnet run --AppTasks=prerender --BaseUrl "${{env.custom_domain}}"
         env:
           custom_domain: "letterbook.com"
-
+      
       - name: Check Generated Files
         run: |
           CHANGED=$(git status --porcelain -uno)

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -123,9 +123,6 @@ jobs:
       - name: Start server
         run: dotnet run --project Letterbook.Web &
 
-      - name: Install Playwright Browsers
-        run: pwsh Letterbook.Web.Tests/bin/Release/net8.0/playwright.ps1 install firefox
-
       - name: E2E Test
         run: dotnet test Letterbook.Web.Tests.E2E --no-build --configuration Release
         env:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -64,7 +64,10 @@ jobs:
         run: pwsh Letterbook.Web.Tests/bin/Release/net8.0/playwright.ps1 install firefox
 
       - name: E2E Test
-        run: BROWSER=firefox dotnet test Letterbook.Web.Tests.E2E --no-build --configuration Release
+        run: dotnet test Letterbook.Web.Tests.E2E --no-build
+        env:
+          BROWSER: firefox
+          DOTNET_ENVIRONMENT: Release
         
       - name: Save test crash report
         if: failure()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,19 +32,18 @@
       - [Debugging Federation](#debugging-federation)
   - [License](#license)
 
-
 ## Code of Conduct
 
 Please read the [Code of Conduct][coc]. It's adapted from the commonly used contributor covenant, but it's not just boilerplate. Be sure you can uphold the project's shared values and abide by the standards laid out in that document. You're more than welcome to ask for clarification.
 
 These values will have a direct impact on the features we do and don't implement, how we prioritize them, and how they are designed. For example:
 
-* We believe tracking and mass data harvesting are dangerous and unethical; we won't build or support those activities and will attempt to limit the personal data we collect
-* We believe that cryptocoins, NFTs, and related technologies are purposefully wasteful and deceptive; we will not incorporate them
-* We believe so-called AI—especially generative AI—is extractive, wasteful, hazardous, and usually deceptive; we will view it with skepticism
-* We will prefer opt-in rather than opt-out dynamics wherever possible
-* We will seek and respect consent, by helping people to make well informed choices without manipulation
-* We will build moderation and administration tools that preserve autonomy and privacy, as well as foster safety
+- We believe tracking and mass data harvesting are dangerous and unethical; we won't build or support those activities and will attempt to limit the personal data we collect
+- We believe that cryptocoins, NFTs, and related technologies are purposefully wasteful and deceptive; we will not incorporate them
+- We believe so-called AI—especially generative AI—is extractive, wasteful, hazardous, and usually deceptive; we will view it with skepticism
+- We will prefer opt-in rather than opt-out dynamics wherever possible
+- We will seek and respect consent, by helping people to make well informed choices without manipulation
+- We will build moderation and administration tools that preserve autonomy and privacy, as well as foster safety
 
 ### Responsible "AI" Contributions
 
@@ -70,10 +69,10 @@ Writing docs is both hard and valuable. Because a lot of things about the projec
 
 We plan to support enough of the Mastodon API to provide good compatibility with Mastodon clients. So you may find these docs to be valuable. They also provide some useful information about how to interoperate with other federated services.
 
-* [Mastodon Docs](https://docs.joinmastodon.org/)
-* [Mastodon API routes](https://docs.joinmastodon.org/dev/routes/)
-* [ActivityPub Spec](https://www.w3.org/TR/activitypub/)
-* [ActivityStreams Vocabulary](https://www.w3.org/TR/activitystreams-vocabulary/)
+- [Mastodon Docs](https://docs.joinmastodon.org/)
+- [Mastodon API routes](https://docs.joinmastodon.org/dev/routes/)
+- [ActivityPub Spec](https://www.w3.org/TR/activitypub/)
+- [ActivityStreams Vocabulary](https://www.w3.org/TR/activitystreams-vocabulary/)
 
 ## Development
 
@@ -88,30 +87,34 @@ This will get you up an running quickly. You can skip ahead for some discussion 
 0. [Install the dotnet 8 SDK][dotnet] and a docker runtime with docker compose (either [docker desktop][docker] or [podman][podman] should work)
 
 1. Start up the database
+
 ```shell
 docker-compose up -d
 ```
 
 2. Migrate the database
+
 ```shell
-dotnet tool retore
+dotnet tool restore
 dotnet ef database update --project Letterbook.Adapter.Db/Letterbook.Adapter.Db.csproj
 dotnet ef database update --project Letterbook.Adapter.TimescaleFeeds/Letterbook.Adapter.TimescaleFeeds.csproj
 ```
 
 3. Add an application host secret
+
 ```shell
 dotnet user-secrets set "HostSecret" "$(openssl rand -base64 32)" --project Letterbook
 ```
 
 4. Run Letterbook (in watch mode)
+
 ```shell
 dotnet restore Letterbook.sln
 dotnet watch run --project Letterbook.Web
 ```
 
 5. Open the UI http://localhost:5127  
-There is also a Swagger UI http://localhost:5127/swagger/index.html
+   There is also a Swagger UI http://localhost:5127/swagger/index.html
 
 ### Navigating the Codebase
 
@@ -148,23 +151,24 @@ All the workers are defined and configured in the Workers project.
 
 Other adapters may of course be involved. If a change requires a new or updated db query, that would happen in the Adapters.Db project. That's also where db migrations are configured. The TimescaleFeeds project plays a critical role with timelines and notifications. Other adapters are critical when working with their respective features.
 
-
 ### Running the Server
 
 > [!IMPORTANT]
 > The build depends on some dotnet tools to generate some docs and assets.  
-> You must run `dotnet tool restore` to get the tools before you build the project for the first time. 
+> You must run `dotnet tool restore` to get the tools before you build the project for the first time.
 
-Letterbook is meant to be easy to set up and run. The default `Letterbook` host project provides all the functionality of the service. However, it's also possible to run the major components on their own. In development, you can run the `Letterbook` project from any of the launch settings. 
+Letterbook is meant to be easy to set up and run. The default `Letterbook` host project provides all the functionality of the service. However, it's also possible to run the major components on their own. In development, you can run the `Letterbook` project from any of the launch settings.
 
 ### Running tests
 
 The Letterbook.sln contains the full set of unit and integration tests. Unit tests have zero dependencies, and they should run in just a few seconds. Integration tests depend on hosting or connecting to real services, and will also take longer to run. To run all tests, simply run the default test command.
+
 ```shell
 dotnet test
 ```
 
-There is also a solution filter that excludes the integration tests. To run only unit tests, target that solution file when running dotnet test. If you're using Jetbrains Rider or Visual Studio, you can also open that `.slnf` file like a solution. 
+There is also a solution filter that excludes the integration tests. To run only unit tests, target that solution file when running dotnet test. If you're using Jetbrains Rider or Visual Studio, you can also open that `.slnf` file like a solution.
+
 ```shell
 dotnet test Letterbook.UnitTests.slnf
 ```
@@ -184,9 +188,11 @@ Tests can be run from the built-in test runner.
 ### Dependencies
 
 #### ~~_Docker_~~
+
 Docker is _not_ actually a dependency for Letterbook. We use docker as a convenient way to manage our other dependencies in development, but you can use other methods if you prefer. To do that, you should read on to the following sections. We don't plan to ever introduce a real dependency on Docker, although we will likely (eventually) publish a docker container image for admins who prefer that option.
 
 #### Postgresql
+
 Letterbook depends on a Postgres database. It attempts to seed an initial administrator account on startup, so you must have the database available in order to run the app. Letterbook depends on the database for essentially everything, so even if we didn't require it on start up, we would require it for any API call you could make.
 
 If it's your first time setting up the database you will need to apply the Database migrations by running the entity framework tools.
@@ -194,6 +200,7 @@ If it's your first time setting up the database you will need to apply the Datab
 This process is documented in more detail at [Letterbook.Adapter.Db](Letterbook.Adapter.Db/readme.md).
 
 #### Host secrets
+
 Letterbook depends on a host secret which comes from a secret provider in order to mint and validate authentication tokens. In development, you can use Dotnet user secrets. (We don't have a production solution, yet 😅). In the interest of developing good security practice, this is not something we can provide in the repository. You have to generate your own secret.
 
 > [!NOTE]
@@ -213,7 +220,7 @@ At the moment, Letterbook uses `System.Security.Cryptography` for its RSA implem
 System.PlatformNotSupportedException: OpenSSL is required for algorithm 'RSAOpenSsl' but could not be found
 ```
 
-You can fix this by installing OpenSSL via [Homebrew](https://brew.sh) and providing its library path to the dotnet 
+You can fix this by installing OpenSSL via [Homebrew](https://brew.sh) and providing its library path to the dotnet
 runtime. This is done by setting the environment variable `DYLD_LIBRARY_PATH`. The correct value might vary by version,
 but it's likely to be `/opt/homebrew/opt/openssl@3/lib`.
 
@@ -226,7 +233,7 @@ local launch configuration in Rider and configuring the environment variable the
 
 ![Screenshot of an example Rider launch configuration that specifies the library path](docs/rider-macos-openssl-launch-config.png)
 
-For test runs, you can set the path in Rider settings: 
+For test runs, you can set the path in Rider settings:
 Settings -> Build, Execution, Deployment -> Unit Testing -> Test Runner
 
 ![Screenshot of an example Rider test runner configuration that specifies the library path](docs/rider-macos-openssl-test-runner.png)
@@ -249,18 +256,20 @@ One of the backends we provide is Prometheus, a very popular metrics database. B
 
 The solution that seems to work best is to tunnel those connections through a unix domain socket. So, if you're running rootless docker on linux, and you want the full range of telemetry data for your dashboards, there are a couple of extra steps.
 
-1. Add the `rootless.yml` overlay to the docker-compose.yml file  
+1. Add the `rootless.yml` overlay to the docker-compose.yml file
+
 ```shell
 docker compose -f docker-compose.yml -f rootless.yml up -d
-```  
-  
-This will set up a socat container in the docker networking namespace, listening on port 3000 and forwarding to a socket that is mounted as a volume in the container. Prometheus will scrape this endpoint instead of the special docker host domain.  
-  
-2. Use `socat` on the host to listen on the same socket and then forward to Letterbook    
+```
+
+This will set up a socat container in the docker networking namespace, listening on port 3000 and forwarding to a socket that is mounted as a volume in the container. Prometheus will scrape this endpoint instead of the special docker host domain.
+
+2. Use `socat` on the host to listen on the same socket and then forward to Letterbook
+
 ```shell
 ./scripts/socket.sh
-```  
-  
+```
+
 #### Debugging Federation
 
 In addition to Letterbook's own dependencies, you may find it useful to have a 3rd party system to exercise federation. The [Letterbook Sandcastles project][sandcastles] provides pre-configured instances of some other fediverse software. We encourage you to make use of that, and to contribute configurations for any other federated peers you're familiar with.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,18 +32,19 @@
       - [Debugging Federation](#debugging-federation)
   - [License](#license)
 
+
 ## Code of Conduct
 
 Please read the [Code of Conduct][coc]. It's adapted from the commonly used contributor covenant, but it's not just boilerplate. Be sure you can uphold the project's shared values and abide by the standards laid out in that document. You're more than welcome to ask for clarification.
 
 These values will have a direct impact on the features we do and don't implement, how we prioritize them, and how they are designed. For example:
 
-- We believe tracking and mass data harvesting are dangerous and unethical; we won't build or support those activities and will attempt to limit the personal data we collect
-- We believe that cryptocoins, NFTs, and related technologies are purposefully wasteful and deceptive; we will not incorporate them
-- We believe so-called AI—especially generative AI—is extractive, wasteful, hazardous, and usually deceptive; we will view it with skepticism
-- We will prefer opt-in rather than opt-out dynamics wherever possible
-- We will seek and respect consent, by helping people to make well informed choices without manipulation
-- We will build moderation and administration tools that preserve autonomy and privacy, as well as foster safety
+* We believe tracking and mass data harvesting are dangerous and unethical; we won't build or support those activities and will attempt to limit the personal data we collect
+* We believe that cryptocoins, NFTs, and related technologies are purposefully wasteful and deceptive; we will not incorporate them
+* We believe so-called AI—especially generative AI—is extractive, wasteful, hazardous, and usually deceptive; we will view it with skepticism
+* We will prefer opt-in rather than opt-out dynamics wherever possible
+* We will seek and respect consent, by helping people to make well informed choices without manipulation
+* We will build moderation and administration tools that preserve autonomy and privacy, as well as foster safety
 
 ### Responsible "AI" Contributions
 
@@ -69,10 +70,10 @@ Writing docs is both hard and valuable. Because a lot of things about the projec
 
 We plan to support enough of the Mastodon API to provide good compatibility with Mastodon clients. So you may find these docs to be valuable. They also provide some useful information about how to interoperate with other federated services.
 
-- [Mastodon Docs](https://docs.joinmastodon.org/)
-- [Mastodon API routes](https://docs.joinmastodon.org/dev/routes/)
-- [ActivityPub Spec](https://www.w3.org/TR/activitypub/)
-- [ActivityStreams Vocabulary](https://www.w3.org/TR/activitystreams-vocabulary/)
+* [Mastodon Docs](https://docs.joinmastodon.org/)
+* [Mastodon API routes](https://docs.joinmastodon.org/dev/routes/)
+* [ActivityPub Spec](https://www.w3.org/TR/activitypub/)
+* [ActivityStreams Vocabulary](https://www.w3.org/TR/activitystreams-vocabulary/)
 
 ## Development
 
@@ -87,13 +88,11 @@ This will get you up an running quickly. You can skip ahead for some discussion 
 0. [Install the dotnet 8 SDK][dotnet] and a docker runtime with docker compose (either [docker desktop][docker] or [podman][podman] should work)
 
 1. Start up the database
-
 ```shell
 docker-compose up -d
 ```
 
 2. Migrate the database
-
 ```shell
 dotnet tool restore
 dotnet ef database update --project Letterbook.Adapter.Db/Letterbook.Adapter.Db.csproj
@@ -101,20 +100,18 @@ dotnet ef database update --project Letterbook.Adapter.TimescaleFeeds/Letterbook
 ```
 
 3. Add an application host secret
-
 ```shell
 dotnet user-secrets set "HostSecret" "$(openssl rand -base64 32)" --project Letterbook
 ```
 
 4. Run Letterbook (in watch mode)
-
 ```shell
 dotnet restore Letterbook.sln
 dotnet watch run --project Letterbook.Web
 ```
 
 5. Open the UI http://localhost:5127  
-   There is also a Swagger UI http://localhost:5127/swagger/index.html
+There is also a Swagger UI http://localhost:5127/swagger/index.html
 
 ### Navigating the Codebase
 
@@ -151,24 +148,23 @@ All the workers are defined and configured in the Workers project.
 
 Other adapters may of course be involved. If a change requires a new or updated db query, that would happen in the Adapters.Db project. That's also where db migrations are configured. The TimescaleFeeds project plays a critical role with timelines and notifications. Other adapters are critical when working with their respective features.
 
+
 ### Running the Server
 
 > [!IMPORTANT]
 > The build depends on some dotnet tools to generate some docs and assets.  
-> You must run `dotnet tool restore` to get the tools before you build the project for the first time.
+> You must run `dotnet tool restore` to get the tools before you build the project for the first time. 
 
-Letterbook is meant to be easy to set up and run. The default `Letterbook` host project provides all the functionality of the service. However, it's also possible to run the major components on their own. In development, you can run the `Letterbook` project from any of the launch settings.
+Letterbook is meant to be easy to set up and run. The default `Letterbook` host project provides all the functionality of the service. However, it's also possible to run the major components on their own. In development, you can run the `Letterbook` project from any of the launch settings. 
 
 ### Running tests
 
 The Letterbook.sln contains the full set of unit and integration tests. Unit tests have zero dependencies, and they should run in just a few seconds. Integration tests depend on hosting or connecting to real services, and will also take longer to run. To run all tests, simply run the default test command.
-
 ```shell
 dotnet test
 ```
 
-There is also a solution filter that excludes the integration tests. To run only unit tests, target that solution file when running dotnet test. If you're using Jetbrains Rider or Visual Studio, you can also open that `.slnf` file like a solution.
-
+There is also a solution filter that excludes the integration tests. To run only unit tests, target that solution file when running dotnet test. If you're using Jetbrains Rider or Visual Studio, you can also open that `.slnf` file like a solution. 
 ```shell
 dotnet test Letterbook.UnitTests.slnf
 ```
@@ -188,11 +184,9 @@ Tests can be run from the built-in test runner.
 ### Dependencies
 
 #### ~~_Docker_~~
-
 Docker is _not_ actually a dependency for Letterbook. We use docker as a convenient way to manage our other dependencies in development, but you can use other methods if you prefer. To do that, you should read on to the following sections. We don't plan to ever introduce a real dependency on Docker, although we will likely (eventually) publish a docker container image for admins who prefer that option.
 
 #### Postgresql
-
 Letterbook depends on a Postgres database. It attempts to seed an initial administrator account on startup, so you must have the database available in order to run the app. Letterbook depends on the database for essentially everything, so even if we didn't require it on start up, we would require it for any API call you could make.
 
 If it's your first time setting up the database you will need to apply the Database migrations by running the entity framework tools.
@@ -200,7 +194,6 @@ If it's your first time setting up the database you will need to apply the Datab
 This process is documented in more detail at [Letterbook.Adapter.Db](Letterbook.Adapter.Db/readme.md).
 
 #### Host secrets
-
 Letterbook depends on a host secret which comes from a secret provider in order to mint and validate authentication tokens. In development, you can use Dotnet user secrets. (We don't have a production solution, yet 😅). In the interest of developing good security practice, this is not something we can provide in the repository. You have to generate your own secret.
 
 > [!NOTE]
@@ -220,7 +213,7 @@ At the moment, Letterbook uses `System.Security.Cryptography` for its RSA implem
 System.PlatformNotSupportedException: OpenSSL is required for algorithm 'RSAOpenSsl' but could not be found
 ```
 
-You can fix this by installing OpenSSL via [Homebrew](https://brew.sh) and providing its library path to the dotnet
+You can fix this by installing OpenSSL via [Homebrew](https://brew.sh) and providing its library path to the dotnet 
 runtime. This is done by setting the environment variable `DYLD_LIBRARY_PATH`. The correct value might vary by version,
 but it's likely to be `/opt/homebrew/opt/openssl@3/lib`.
 
@@ -233,7 +226,7 @@ local launch configuration in Rider and configuring the environment variable the
 
 ![Screenshot of an example Rider launch configuration that specifies the library path](docs/rider-macos-openssl-launch-config.png)
 
-For test runs, you can set the path in Rider settings:
+For test runs, you can set the path in Rider settings: 
 Settings -> Build, Execution, Deployment -> Unit Testing -> Test Runner
 
 ![Screenshot of an example Rider test runner configuration that specifies the library path](docs/rider-macos-openssl-test-runner.png)
@@ -256,20 +249,18 @@ One of the backends we provide is Prometheus, a very popular metrics database. B
 
 The solution that seems to work best is to tunnel those connections through a unix domain socket. So, if you're running rootless docker on linux, and you want the full range of telemetry data for your dashboards, there are a couple of extra steps.
 
-1. Add the `rootless.yml` overlay to the docker-compose.yml file
-
+1. Add the `rootless.yml` overlay to the docker-compose.yml file  
 ```shell
 docker compose -f docker-compose.yml -f rootless.yml up -d
-```
-
-This will set up a socat container in the docker networking namespace, listening on port 3000 and forwarding to a socket that is mounted as a volume in the container. Prometheus will scrape this endpoint instead of the special docker host domain.
-
-2. Use `socat` on the host to listen on the same socket and then forward to Letterbook
-
+```  
+  
+This will set up a socat container in the docker networking namespace, listening on port 3000 and forwarding to a socket that is mounted as a volume in the container. Prometheus will scrape this endpoint instead of the special docker host domain.  
+  
+2. Use `socat` on the host to listen on the same socket and then forward to Letterbook    
 ```shell
 ./scripts/socket.sh
-```
-
+```  
+  
 #### Debugging Federation
 
 In addition to Letterbook's own dependencies, you may find it useful to have a 3rd party system to exercise federation. The [Letterbook Sandcastles project][sandcastles] provides pre-configured instances of some other fediverse software. We encourage you to make use of that, and to contribute configurations for any other federated peers you're familiar with.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,6 +40,8 @@
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.0.1" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.45.1" />
+    <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.45.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.3" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
     <PackageVersion Include="MockQueryable.Moq" Version="7.0.1" />
@@ -52,6 +54,12 @@
     <PackageVersion Include="NSign.AspNetCore" Version="1.0.3" />
     <PackageVersion Include="NSign.Client" Version="1.0.3" />
     <PackageVersion Include="NSign.SignatureProviders" Version="1.0.3" />
+    <PackageVersion Include="Nunit" Version="4.1.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageVersion>
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="5.7.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.9.0-beta.2" />

--- a/Letterbook.Web.Tests.E2E/LandingPageValidationTest.cs
+++ b/Letterbook.Web.Tests.E2E/LandingPageValidationTest.cs
@@ -1,0 +1,23 @@
+using System.Text.RegularExpressions;
+using Letterbook.Web.Tests.E2E.Support;
+
+namespace Letterbook.Web.Tests.E2E;
+
+[Parallelizable(ParallelScope.Self)]
+[TestFixture]
+public class LandingPageValidationTest : PageTest
+{
+	[Test]
+	public async Task HomepageHasCorrectTitleAndLinksToAdminProfile()
+	{
+		await Page.GotoAsync(Settings.BaseUrl.ToString());
+
+		await Expect(Page).ToHaveTitleAsync(new Regex("Letterbook.Web"));
+
+		// Get link to admin profile
+		var adminProfileLink = Page.GetByRole(AriaRole.Link, new() { Name = "Admin profile" });
+
+		// Expect an attribute "to be strictly equal" to the value.
+		await Expect(adminProfileLink).ToHaveAttributeAsync("href", "/@admin");
+	}
+}

--- a/Letterbook.Web.Tests.E2E/Letterbook.Web.Tests.E2E.csproj
+++ b/Letterbook.Web.Tests.E2E/Letterbook.Web.Tests.E2E.csproj
@@ -1,0 +1,37 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="coverlet.collector">
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" />
+      <PackageReference Include="Microsoft.Playwright" />
+      <PackageReference Include="Microsoft.Playwright.NUnit" />
+      <PackageReference Include="Nunit" />
+      <PackageReference Include="NUnit.Analyzers">
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
+      <PackageReference Include="NUnit3TestAdapter" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Letterbook.Adapter.ActivityPub\Letterbook.Adapter.ActivityPub.csproj" />
+      <ProjectReference Include="..\Letterbook.Adapter.Db\Letterbook.Adapter.Db.csproj" />
+      <ProjectReference Include="..\Letterbook.Adapter.TimescaleFeeds\Letterbook.Adapter.TimescaleFeeds.csproj" />
+      <ProjectReference Include="..\Letterbook.AspNet\Letterbook.AspNet.csproj" />
+      <ProjectReference Include="..\Letterbook.Core\Letterbook.Core.csproj" />
+      <ProjectReference Include="..\Letterbook.Web.Tests\Letterbook.Web.Tests.csproj" />
+      <ProjectReference Include="..\Letterbook.Web\Letterbook.Web.csproj" />
+      <ProjectReference Include="..\Letterbook.Workers\Letterbook.Workers.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Letterbook.Web.Tests.E2E/OneTimeSetup.cs
+++ b/Letterbook.Web.Tests.E2E/OneTimeSetup.cs
@@ -1,0 +1,13 @@
+using Playwright = Letterbook.Web.Tests.E2E.Support.Playwright;
+
+namespace Letterbook.Web.Tests.E2E;
+
+[SetUpFixture]
+public class OneTimeSetup
+{
+	[OneTimeSetUp]
+	public void RunBeforeAnyTests()
+	{
+		Playwright.Install();
+	}
+}

--- a/Letterbook.Web.Tests.E2E/README.md
+++ b/Letterbook.Web.Tests.E2E/README.md
@@ -1,0 +1,52 @@
+# E2E Testing for Letterbook.Web
+
+## Setup
+
+This test package uses [Playwright](https://playwright.dev). While most dependencies are provided automatically for you, Playwright will require you to install test browsers to run these tests.
+
+You can find out more about this at https://playwright.dev/dotnet/docs/intro
+
+Or use
+
+```shell
+dotnet build
+pwsh bin/Debug/netX/playwright.ps1 install
+```
+
+To install browser dependencies. This requires powershell to be installed.
+
+> Note: You need to replace `netX` above with the version of .NET you are using. For example `pwsh .\bin\Debug\net7.0\playwright.ps1 install`
+
+## Examples
+
+### Choose browser and run headed
+
+```shell
+BROWSER=firefox HEADED=1 dotnet test Letterbook.Web.Tests.E2E/Letterbook.Web.Tests.E2E.csproj
+```
+
+[More options](https://playwright.dev/dotnet/docs/test-runners#customizing-browserlaunch-options-1).
+
+### Filter by name
+
+```shell
+BROWSER=firefox HEADED=1 dotnet test Letterbook.Web.Tests.E2E/Letterbook.Web.Tests.E2E.csproj --filter Name~Landing
+```
+
+[More options](https://playwright.dev/dotnet/docs/running-tests).
+
+## Common Errors
+
+### Executable doesn't exist at **/chrome.exe | **/firefox.exe
+
+Playwright uses custom headless versions of common browsers to execute its tests. If your seeing an error that chrome/firefox etc can not be found this does not mean you need to reinstall your browsers. Instead you'll need to run the configuration script provided by Playwright to install the necessary browsers for the test clients to run.
+
+Playwright should have provided a hint to install the needed browser tooling or you can use the Setup steps above.
+
+### The argument 'bin/Debug/netX/playwright.ps1' is not recognized as the name of a script file.
+
+`netX` is a placeholder for the version of .NET you are using. You should replace that with the correct version and try again.
+
+### Npgsql.NpgsqlException : Failed to connect to 127.0.0.1:5432
+
+When running on the build server this is because it expecting a database to exist first.

--- a/Letterbook.Web.Tests.E2E/README.md
+++ b/Letterbook.Web.Tests.E2E/README.md
@@ -2,9 +2,9 @@
 
 ## Setup
 
-This test package uses [Playwright](https://playwright.dev). While most dependencies are provided automatically for you, Playwright will require you to install test browsers to run these tests.
+This test package uses [Playwright](https://playwright.dev). Browsers are automaticaly installed during the test run, but you can also install them manually.
 
-You can find out more about this at https://playwright.dev/dotnet/docs/intro
+You can find out more about this at https://playwright.dev/dotnet/docs/intro.
 
 Or use
 

--- a/Letterbook.Web.Tests.E2E/SelfStartedWebServerExampleTest.cs
+++ b/Letterbook.Web.Tests.E2E/SelfStartedWebServerExampleTest.cs
@@ -22,27 +22,13 @@ public class SelfStartedWebServerExampleTest : PageTest
 		await _webServerFixture.DisposeAsync();
 	}
 
-	/*
-
-		Included because it demonstrates that the server *is* configured and working
-
-	*/
 	[Test]
 	public async Task HomepageHasAFavicon()
 	{
 		await Page.GotoAsync($"{_webServerFixture.BaseUrl}favicon");
 	}
 
-	/*
-
-		Help wanted.
-
-		This test fails because (I think) razor pages are not able to render.
-
-		See: Letterbook.Web.Tests.E2E/Support/WebServerFixture.cs
-
-	*/
-	[Ignore("[WIP] Need help to make this work, see `WebServerFixture`")]
+	[Test]
 	public async Task HomepageHasCorrectTitleAndLinksToAdminProfile()
 	{
 		await Page.GotoAsync(_webServerFixture.BaseUrl.ToString());

--- a/Letterbook.Web.Tests.E2E/SelfStartedWebServerExampleTest.cs
+++ b/Letterbook.Web.Tests.E2E/SelfStartedWebServerExampleTest.cs
@@ -1,0 +1,58 @@
+using System.Text.RegularExpressions;
+using Letterbook.Web.Tests.E2E.Support;
+
+namespace Letterbook.Web.Tests.E2E;
+
+[Parallelizable(ParallelScope.Self)]
+[TestFixture]
+public class SelfStartedWebServerExampleTest : PageTest
+{
+	private WebServerFixture _webServerFixture;
+
+	[OneTimeSetUp]
+	public async Task BeforeAll()
+	{
+		_webServerFixture = new WebServerFixture();
+		await _webServerFixture.InitializeAsync();
+	}
+
+	[OneTimeTearDown]
+	public async Task AfterAll()
+	{
+		await _webServerFixture.DisposeAsync();
+	}
+
+	/*
+
+		Included because it demonstrates that the server *is* configured and working
+
+	*/
+	[Test]
+	public async Task HomepageHasAFavicon()
+	{
+		await Page.GotoAsync($"{_webServerFixture.BaseUrl}favicon");
+	}
+
+	/*
+
+		Help wanted.
+
+		This test fails because (I think) razor pages are not able to render.
+
+		See: Letterbook.Web.Tests.E2E/Support/WebServerFixture.cs
+
+	*/
+	[Ignore("[WIP] Need help to make this work, see `WebServerFixture`")]
+	public async Task HomepageHasCorrectTitleAndLinksToAdminProfile()
+	{
+		await Page.GotoAsync(_webServerFixture.BaseUrl.ToString());
+
+		await Expect(Page).ToHaveTitleAsync(new Regex("Letterbook.Web"));
+
+		// Get link to admin profile
+		var adminProfileLink = Page.GetByRole(AriaRole.Link, new() { Name = "Admin profile" });
+
+		// Expect an attribute "to be strictly equal" to the value.
+		await Expect(adminProfileLink).ToHaveAttributeAsync("href", "/@admin");
+	}
+}

--- a/Letterbook.Web.Tests.E2E/Support/Playwright.cs
+++ b/Letterbook.Web.Tests.E2E/Support/Playwright.cs
@@ -1,0 +1,22 @@
+namespace Letterbook.Web.Tests.E2E.Support;
+
+public static class Playwright
+{
+	/*
+		Equivalent to:
+
+			pwsh Letterbook.Web.Tests/bin/Release/net8.0/playwright.ps1 install firefox
+
+		See: https://playwright.dev/dotnet/docs/browsers#managing-browser-binaries for where binaries go to.
+		See: https://playwright.dev/dotnet/docs/browsers#install-browsers for more options
+	*/
+	public static void Install()
+	{
+		var exitCode = Microsoft.Playwright.Program.Main(new [] { "install", "firefox" });
+
+		if (exitCode != 0)
+		{
+			throw new Exception($"Playwright exited with code {exitCode}");
+		}
+	}
+}

--- a/Letterbook.Web.Tests.E2E/Support/Settings.cs
+++ b/Letterbook.Web.Tests.E2E/Support/Settings.cs
@@ -1,0 +1,13 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace Letterbook.Web.Tests.E2E.Support;
+
+static class Settings
+{
+	public const int DefaultPort = 5127;
+	public static Uri BaseUrl = new(Get(nameof(BaseUrl), $"http://localhost:{DefaultPort}"));
+
+	private static string Get(string name, string @default)
+		=> Environment.GetEnvironmentVariable(name) ?? @default;
+}

--- a/Letterbook.Web.Tests.E2E/Support/WebServerFixture.cs
+++ b/Letterbook.Web.Tests.E2E/Support/WebServerFixture.cs
@@ -59,7 +59,12 @@ public class WebServerFixture
 			@todo: Try `UseStartUp` again
 
 		*/
-		var builder = WebApplication.CreateBuilder();
+		var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+		{
+			// [!] Force the web application to read from `appsettings.Development.json`.
+			// This is required because the tests are built and run in release mode.
+			EnvironmentName = "Development"
+		});
 
 		// Pre initialize Serilog
 		Log.Logger = new LoggerConfiguration()

--- a/Letterbook.Web.Tests.E2E/Support/WebServerFixture.cs
+++ b/Letterbook.Web.Tests.E2E/Support/WebServerFixture.cs
@@ -22,7 +22,6 @@ using Serilog;
 using Serilog.Enrichers.Span;
 using Serilog.Events;
 
-// ReSharper disable once CheckNamespace
 namespace Letterbook.Web;
 
 public class WebServerFixture
@@ -118,17 +117,6 @@ public class WebServerFixture
 		builder.WebHost.UseUrls(BaseUrl.ToString());
 
 		var app = builder.Build();
-
-		// Configure the HTTP request pipeline.
-		if (!app.Environment.IsDevelopment())
-		{
-			// Not sure if this works, with mixed Razor/WebApi
-			// app.UseExceptionHandler("/Error");
-			app.UseExceptionHandler((applicationBuilder =>
-			{
-				Console.WriteLine("Error handler");
-			}));
-		}
 
 		if (!app.Environment.IsProduction())
 		{

--- a/Letterbook.Web.Tests.E2E/Support/WebServerFixture.cs
+++ b/Letterbook.Web.Tests.E2E/Support/WebServerFixture.cs
@@ -69,9 +69,6 @@ public class WebServerFixture
 			.WriteTo.Console()
 			.CreateBootstrapLogger();
 
-		var coreOptions = builder.Configuration.GetSection(CoreOptions.ConfigKey).Get<CoreOptions>()
-		                  ?? throw new ConfigException(nameof(CoreOptions));
-
 		if (!builder.Environment.IsProduction())
 			builder.Configuration.AddUserSecrets<Program>();
 		// Register Serilog - Serialized Logging (configured in appsettings.json)

--- a/Letterbook.Web.Tests.E2E/Support/WebServerFixture.cs
+++ b/Letterbook.Web.Tests.E2E/Support/WebServerFixture.cs
@@ -1,0 +1,203 @@
+using System.Net;
+using System.Net.Sockets;
+using Letterbook.Adapter.ActivityPub;
+using Letterbook.Adapter.Db;
+using Letterbook.Adapter.TimescaleFeeds;
+using Letterbook.AspNet;
+using Letterbook.Core;
+using Letterbook.Core.Exceptions;
+using Letterbook.Core.Extensions;
+using Letterbook.Workers;
+using MassTransit;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Serilog;
+using Serilog.Enrichers.Span;
+using Serilog.Events;
+
+namespace Letterbook.Web.Tests.E2E.Support;
+
+public class WebServerFixture
+{
+	private IHost? _host;
+	public Uri BaseUrl { get; private set; } = Settings.BaseUrl;
+
+	public async Task InitializeAsync(int? port = null)
+	{
+		BaseUrl = new Uri($"http://localhost:{port ?? GetRandomUnusedPort()}");
+
+		CreateHost();
+
+		if (_host != null)
+		{
+			await _host.StartAsync();
+		}
+	}
+
+	private void CreateHost()
+	{
+		Log.Logger = new LoggerConfiguration()
+			.MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+			.Enrich.FromLogContext()
+			.Enrich.WithSpan()
+			.WriteTo.Console()
+			.CreateBootstrapLogger();
+
+		// @todo: Is there more stable way to calculate this?
+		var contentRootPath = Path.GetFullPath(Path.Combine("..", "..", "..", "..", "Letterbook.Web"));
+		var razorPagesRootDirectory = Path.Combine(contentRootPath, "Pages");
+
+		Log.Logger.Information($"Starting server at <{BaseUrl}>");
+		Log.Logger.Information($"CurrentDirectory: {Directory.GetCurrentDirectory()}");
+		Log.Logger.Information($"ContentRootPath: {contentRootPath}");
+		Log.Logger.Information($"RazorPagesRootDirectory: {razorPagesRootDirectory}");
+
+		/*
+
+			Wow I can NOT make `UseStartUp` work so using inline definition based on `Program.cs`.
+
+			@todo: Try `UseStartUp` again
+
+		*/
+		var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+		{
+			ContentRootPath = contentRootPath, // Letterbook/Letterbook.Web.Tests/bin/Debug/net8.0
+			WebRootPath = "wwwroot",
+			EnvironmentName = "Development",
+			Args = []
+		});
+
+		// Pre initialize Serilog
+		Log.Logger = new LoggerConfiguration()
+			.MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+			.Enrich.FromLogContext()
+			.Enrich.WithSpan()
+			.WriteTo.Console()
+			.CreateBootstrapLogger();
+
+		var coreOptions = builder.Configuration.GetSection(CoreOptions.ConfigKey).Get<CoreOptions>()
+		                  ?? throw new ConfigException(nameof(CoreOptions));
+
+		if (!builder.Environment.IsProduction())
+			builder.Configuration.AddUserSecrets<Program>();
+		// Register Serilog - Serialized Logging (configured in appsettings.json)
+		builder.Host.UseSerilog((context, services, configuration) => configuration
+			.Enrich.FromLogContext()
+			.Enrich.WithSpan()
+			.ReadFrom.Configuration(context.Configuration)
+			.ReadFrom.Services(services)
+		);
+		builder.Services.AddOpenTelemetry()
+			.AddDbTelemetry()
+			.AddClientTelemetry()
+			.AddTelemetryExporters();
+		builder.Services
+			.AddSerilog(s => s.Enrich.FromLogContext()
+				.Enrich.WithSpan()
+				.ReadFrom.Configuration(builder.Configuration))
+			.AddMassTransit(bus => bus.AddWorkers(builder.Configuration)
+				.AddWorkerBus(builder.Configuration))
+			.AddPublishers()
+			.AddLetterbookCore(builder.Configuration)
+			.AddDbAdapter(builder.Configuration)
+			.AddFeedsAdapter(builder.Configuration)
+			.AddActivityPubClient(builder.Configuration)
+			.AddWebCookies();
+		builder.Services.AddIdentity<Core.Models.Account, IdentityRole<Guid>>(identity => identity.ConfigureIdentity())
+			.AddEntityFrameworkStores<RelationalContext>()
+			.AddDefaultTokenProviders()
+			// Aspnet Core Identity includes a default UI, which provides basic account management.
+			// This includes register, login, logout, and maintenance views.
+			// However, it only seems to work well for fairly simple (single project) apps.  It also looks extremely Microsoft.
+			// We likely don't want to use it long term, but it's nice for the moment.
+			//
+			// We can work around some of the issues by overriding pages under Areas/IdentityPages/Account
+			.AddDefaultUI();
+		builder.Services.AddRazorPages(options =>
+		{
+			options.RootDirectory = razorPagesRootDirectory;
+		});
+		builder.Services.AddAuthorization(options =>
+		{
+			options.AddWebAuthzPolicy();
+		});
+
+		builder.WebHost.UseUrls(BaseUrl.ToString());
+
+		var app = builder.Build();
+
+		// Configure the HTTP request pipeline.
+		if (!app.Environment.IsDevelopment())
+		{
+			// Not sure if this works, with mixed Razor/WebApi
+			app.UseExceptionHandler("/Error");
+		}
+
+		if (!app.Environment.IsProduction())
+		{
+			app.Use((context, next) =>
+			{
+				context.Request.EnableBuffering();
+				return next();
+			});
+		}
+
+		app.UseStaticFiles();
+
+		app.UseHealthChecks("/healthz");
+		app.MapPrometheusScrapingEndpoint();
+
+		app.UseAuthentication();
+		app.UseAuthorization();
+		app.UseSerilogRequestLogging();
+
+		app.UseWhen(context => !context.Request.Path.StartsWithSegments("/Identity"), applicationBuilder =>
+		{
+			applicationBuilder.UseMiddleware<ProfileIdentityMiddleware>();
+		});
+
+		app.MapRazorPages();
+
+		_host = app;
+	}
+
+	public Task DisposeAsync()
+	{
+		if (_host != null)
+		{
+			_host.Dispose();
+		}
+		return Task.CompletedTask;
+	}
+
+	private static int GetRandomUnusedPort()
+	{
+		using var listener = new TcpListener(IPAddress.Any, 0);
+
+		listener.Start();
+		var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+		listener.Stop();
+
+		return port;
+	}
+
+	private static bool LocalHostPortIsInUse(Uri url)
+	{
+		using var tc = new TcpClient();
+
+		try
+		{
+			tc.Connect(IPAddress.Loopback, url.Port);
+			return tc.Connected;
+		}
+		catch (SocketException)
+		{
+			return false;
+		}
+	}
+}

--- a/Letterbook.Web.Tests.E2E/Using.cs
+++ b/Letterbook.Web.Tests.E2E/Using.cs
@@ -1,0 +1,3 @@
+global using NUnit.Framework;
+global using Microsoft.Playwright;
+global using Microsoft.Playwright.NUnit;

--- a/Letterbook.Web.Tests/Letterbook.Web.Tests.csproj
+++ b/Letterbook.Web.Tests/Letterbook.Web.Tests.csproj
@@ -17,6 +17,7 @@
         </PackageReference>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Microsoft.Playwright" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -32,5 +33,4 @@
       <ProjectReference Include="..\Letterbook.Core.Tests\Letterbook.Core.Tests.csproj" />
       <ProjectReference Include="..\Letterbook.Web\Letterbook.Web.csproj" />
     </ItemGroup>
-
 </Project>

--- a/Letterbook.sln
+++ b/Letterbook.sln
@@ -105,6 +105,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{801E
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Letterbook.Docs", "Letterbook.Docs\Letterbook.Docs.csproj", "{E59A87C4-FB3F-4A63-AE77-66E05F254779}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Letterbook.Web.Tests.E2E", "Letterbook.Web.Tests.E2E\Letterbook.Web.Tests.E2E.csproj", "{2585EF85-3590-4C4D-8701-9B135D8BB229}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -194,6 +196,10 @@ Global
 		{E59A87C4-FB3F-4A63-AE77-66E05F254779}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E59A87C4-FB3F-4A63-AE77-66E05F254779}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E59A87C4-FB3F-4A63-AE77-66E05F254779}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2585EF85-3590-4C4D-8701-9B135D8BB229}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2585EF85-3590-4C4D-8701-9B135D8BB229}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2585EF85-3590-4C4D-8701-9B135D8BB229}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2585EF85-3590-4C4D-8701-9B135D8BB229}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{25C320AC-E149-44F9-81F3-5275C7D8D334} = {DFA1FACC-AC5C-4B25-A0E4-718957C70BC3}


### PR DESCRIPTION
## Green build with development server

The changes here have the build passing with this end-to-end test from #207 

https://github.com/ben-biddington/Letterbook/blob/f/add-playwright-testing-project-to-main-%23205/Letterbook.Web.Tests.E2E/LandingPageValidationTest.cs

So I think you're free to continue in this style if you wanted to while experimenting with the on-demand server idea.

## On-demand server [WIP]

There are also some examples showing how you could run the tests against a server started at runtime:

https://github.com/ben-biddington/Letterbook/blob/f/add-playwright-testing-project-to-main-%23205/Letterbook.Web.Tests.E2E/SelfStartedWebServerExampleTest.cs

This could be useful if you wanted to be able to change the application under test. For example you may wish to substitute some of the services for fakes.

These tests use [`WebServerFixture`](https://github.com/ben-biddington/Letterbook/blob/f/add-playwright-testing-project-to-main-%23205/Letterbook.Web.Tests.E2E/Support/WebServerFixture.cs) to start the server.

I had some trouble with files paths getting it to partially work, and I think there is something missing with the razor pages which is why [HomepageHasCorrectTitleAndLinksToAdminProfile](https://github.com/ben-biddington/Letterbook/blob/f/add-playwright-testing-project-to-main-%23205/Letterbook.Web.Tests.E2E/SelfStartedWebServerExampleTest.cs#L46) is skipped.

(Thanks to @runewake2 for explaining why nunit has been chosen.)

## Related
- https://github.com/Letterbook/Letterbook/pull/207