### PR TITLE
chore: sanitize posts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="DarkLink.Web.WebFinger.Server" Version="1.0.0" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
+    <PackageVersion Include="HtmlSanitizer" Version="8.1.870" />
     <PackageVersion Include="ILogger.Moq" Version="1.1.10" />
     <PackageVersion Include="Markdig" Version="0.37.0" />
     <PackageVersion Include="MassTransit" Version="8.2.3" />

--- a/Letterbook.Adapter.Db/Migrations/20240811185620_ContentTypeRequired.Designer.cs
+++ b/Letterbook.Adapter.Db/Migrations/20240811185620_ContentTypeRequired.Designer.cs
@@ -5,6 +5,7 @@ using Letterbook.Adapter.Db;
 using Letterbook.Core.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Letterbook.Adapter.Db.Migrations
 {
     [DbContext(typeof(RelationalContext))]
-    partial class RelationalContextModelSnapshot : ModelSnapshot
+    [Migration("20240811185620_ContentTypeRequired")]
+    partial class ContentTypeRequired
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Letterbook.Adapter.Db/Migrations/20240811185620_ContentTypeRequired.cs
+++ b/Letterbook.Adapter.Db/Migrations/20240811185620_ContentTypeRequired.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Letterbook.Adapter.Db.Migrations
+{
+    /// <inheritdoc />
+    public partial class ContentTypeRequired : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+	        // Manually added to provide default values for existing null records
+	        migrationBuilder.UpdateData(
+		        column: "ContentType",
+		        table: "Content",
+		        value: "text/html",
+		        keyColumn: "ContentType",
+		        keyValue: null);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ContentType",
+                table: "Content",
+                type: "text",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ContentType",
+                table: "Content",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+        }
+    }
+}

--- a/Letterbook.Core.Tests/MapperTests.cs
+++ b/Letterbook.Core.Tests/MapperTests.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using Letterbook.Core.Models;
 using Letterbook.Core.Models.Dto;
 using Letterbook.Core.Models.Mappers;
 using Letterbook.Core.Tests.Fakes;
@@ -54,6 +55,28 @@ public class MapperTests : WithMocks
 	[InlineData("text/markdown")]
 	[InlineData("text/html")]
 	[InlineData(null)]
+	[Theory(DisplayName = "Should map PostDto with content")]
+	public void MapPostContent(string? type)
+	{
+		var noteDto = new ContentDto
+		{
+			Type = "Note",
+			Text = "test text",
+			SourceContentType = type,
+		};
+		_postDto.Contents.Add(noteDto);
+		var actual = _postMapper.Map<Models.Post>(_postDto);
+
+		Assert.NotNull(actual);
+		var actualNote = Assert.IsType<Note>(actual.Contents.FirstOrDefault());
+		Assert.Equal(type ?? "text/plain", actualNote.SourceContentType?.MediaType);
+		Assert.Equal("text/html", actualNote.ContentType?.MediaType);
+	}
+
+	[InlineData("text/plain")]
+	[InlineData("text/markdown")]
+	[InlineData("text/html")]
+	[InlineData(null)]
 	[Theory(DisplayName = "Should map ContentDto as Note")]
 	public void MapNote(string? type)
 	{
@@ -61,13 +84,13 @@ public class MapperTests : WithMocks
 		{
 			Type = "Note",
 			Text = "test text",
-			ContentType = type,
+			SourceContentType = type,
 		};
-		_postDto.Contents.Add(noteDto);
 		var actual = _postMapper.Map<Models.Note>(noteDto);
 
 		Assert.NotNull(actual);
 		Assert.Equal(type ?? "text/plain", actual.SourceContentType?.ToString());
+		Assert.Equal("text/html", actual.ContentType?.MediaType);
 	}
 
 	[Fact(DisplayName = "Should generate an Id")]

--- a/Letterbook.Core.Tests/Mocks/MockHtmlSanitizer.cs
+++ b/Letterbook.Core.Tests/Mocks/MockHtmlSanitizer.cs
@@ -7,10 +7,12 @@ public class MockHtmlSanitizer : IContentSanitizer
 {
 	public string Sanitize(string content, string baseUrl = "") => content;
 	public ContentType ContentType { get; } = new(Content.HtmlMediaType);
+	public ContentType Result { get; } = new(Content.HtmlMediaType);
 }
 
 public class MockTextSanitizer : IContentSanitizer
 {
 	public string Sanitize(string content, string baseUrl = "") => content;
 	public ContentType ContentType { get; } = new(Content.PlainTextMediaType);
+	public ContentType Result { get; } = new(Content.HtmlMediaType);
 }

--- a/Letterbook.Core.Tests/Mocks/MockHtmlSanitizer.cs
+++ b/Letterbook.Core.Tests/Mocks/MockHtmlSanitizer.cs
@@ -1,0 +1,16 @@
+using System.Net.Mime;
+using Letterbook.Core.Models;
+
+namespace Letterbook.Core.Tests.Mocks;
+
+public class MockHtmlSanitizer : IContentSanitizer
+{
+	public string Sanitize(string content, string baseUrl = "") => content;
+	public ContentType ContentType { get; } = new(Content.HtmlMediaType);
+}
+
+public class MockTextSanitizer : IContentSanitizer
+{
+	public string Sanitize(string content, string baseUrl = "") => content;
+	public ContentType ContentType { get; } = new(Content.PlainTextMediaType);
+}

--- a/Letterbook.Core.Tests/PostServiceTests.cs
+++ b/Letterbook.Core.Tests/PostServiceTests.cs
@@ -1,6 +1,7 @@
 using Letterbook.Core.Exceptions;
 using Letterbook.Core.Models;
 using Letterbook.Core.Tests.Fakes;
+using Letterbook.Core.Tests.Mocks;
 using Medo;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -21,7 +22,8 @@ public class PostServiceTests : WithMocks
 		_output = output;
 		_output.WriteLine($"Bogus seed: {Init.WithSeed()}");
 		_service = new PostService(Mock.Of<ILogger<PostService>>(), CoreOptionsMock,
-			PostAdapterMock.Object, PostEventServiceMock.Object, ActivityPubClientMock.Object);
+			PostAdapterMock.Object, PostEventServiceMock.Object, ActivityPubClientMock.Object,
+			[new MockHtmlSanitizer(), new MockTextSanitizer()]);
 		_fakeProfile = new FakeProfile("letterbook.example");
 		_profile = _fakeProfile.Generate();
 		_post = new FakePost(_profile);

--- a/Letterbook.Core/HtmlSanitizer.cs
+++ b/Letterbook.Core/HtmlSanitizer.cs
@@ -8,4 +8,5 @@ public class HtmlSanitizer(IHtmlSanitizer sanitizer) : IContentSanitizer
 {
 	public string Sanitize(string content, string baseUrl = "") => sanitizer.Sanitize(content, baseUrl);
 	public ContentType ContentType { get; } = new(Content.HtmlMediaType);
+	public ContentType Result { get; } = new(Content.HtmlMediaType);
 }

--- a/Letterbook.Core/HtmlSanitizer.cs
+++ b/Letterbook.Core/HtmlSanitizer.cs
@@ -1,0 +1,11 @@
+using System.Net.Mime;
+using Ganss.Xss;
+using Letterbook.Core.Models;
+
+namespace Letterbook.Core;
+
+public class HtmlSanitizer(IHtmlSanitizer sanitizer) : IContentSanitizer
+{
+	public string Sanitize(string content, string baseUrl = "") => sanitizer.Sanitize(content, baseUrl);
+	public ContentType ContentType { get; } = new(Content.HtmlMediaType);
+}

--- a/Letterbook.Core/IContentSanitizer.cs
+++ b/Letterbook.Core/IContentSanitizer.cs
@@ -6,4 +6,5 @@ public interface IContentSanitizer
 {
 	public string Sanitize(string content, string baseUrl = "");
 	public ContentType ContentType { get; }
+	public ContentType Result { get; }
 }

--- a/Letterbook.Core/IContentSanitizer.cs
+++ b/Letterbook.Core/IContentSanitizer.cs
@@ -1,0 +1,9 @@
+using System.Net.Mime;
+
+namespace Letterbook.Core;
+
+public interface IContentSanitizer
+{
+	public string Sanitize(string content, string baseUrl = "");
+	public ContentType ContentType { get; }
+}

--- a/Letterbook.Core/Letterbook.Core.csproj
+++ b/Letterbook.Core/Letterbook.Core.csproj
@@ -14,6 +14,7 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
+      <PackageReference Include="HtmlSanitizer" />
       <PackageReference Include="MassTransit.Abstractions" />
       <PackageReference Include="Medo.Uuid7" />
       <PackageReference Include="Microsoft.AspNetCore.Identity.UI" />

--- a/Letterbook.Core/Models/Content.cs
+++ b/Letterbook.Core/Models/Content.cs
@@ -6,6 +6,10 @@ namespace Letterbook.Core.Models;
 
 public abstract class Content : IContent, IEquatable<Content>
 {
+	public const string PlainTextMediaType = "text/plain";
+	public const string MarkdownMediaType = "text/markdown";
+	public const string HtmlMediaType = "text/html";
+
 	private Uuid7 _id;
 
 	protected Content()
@@ -13,6 +17,7 @@ public abstract class Content : IContent, IEquatable<Content>
 		_id = Uuid7.NewUuid7();
 		FediId = default!;
 		Post = default!;
+		ContentType = new ContentType(HtmlMediaType);
 	}
 
 	public Guid Id
@@ -28,7 +33,7 @@ public abstract class Content : IContent, IEquatable<Content>
 	public Uri? Source { get; set; }
 	public int? SortKey { get; set; } = 0;
 	public abstract string Type { get; }
-	public ContentType? ContentType { get; set; }
+	public ContentType ContentType { get; set; }
 	public required string Html { get; set; }
 
 	public static Uri LocalId(IContent content, CoreOptions opts) =>
@@ -37,7 +42,7 @@ public abstract class Content : IContent, IEquatable<Content>
 	public Uuid7 GetId() => _id;
 	public string GetId25() => _id.ToId25String();
 	public abstract string? GeneratePreview();
-	public abstract void Sanitize();
+	public abstract void Sanitize(IEnumerable<IContentSanitizer> sanitizers);
 
 	public virtual void UpdateFrom(Content content)
 	{

--- a/Letterbook.Core/Models/Dto/ContentDto.cs
+++ b/Letterbook.Core/Models/Dto/ContentDto.cs
@@ -13,5 +13,5 @@ public class ContentDto
 
 	/// <summary>Required for Notes. The text of the Note.</summary>
 	public string? Text { get; set; }
-	public string? ContentType { get; set; }
+	public string? SourceContentType { get; set; }
 }

--- a/Letterbook.Core/Models/IContent.cs
+++ b/Letterbook.Core/Models/IContent.cs
@@ -15,5 +15,5 @@ public interface IContent
 	public Uuid7 GetId();
 	public string GetId25();
 	public string? GeneratePreview();
-	public void Sanitize();
+	public void Sanitize(IEnumerable<IContentSanitizer> sanitizers);
 }

--- a/Letterbook.Core/Models/Mappers/PostMappings.cs
+++ b/Letterbook.Core/Models/Mappers/PostMappings.cs
@@ -22,11 +22,13 @@ public class PostMappings : AutoMapper.Profile
 			.IncludeBase<Content, ContentDto>()
 			.ForMember(dto => dto.Text, opt => opt.MapFrom(src => src.SourceText));
 		CreateMap<Content, ContentDto>(MemberList.Destination)
+			.ForMember(dest => dest.SourceContentType, opt => opt.Ignore())
 			.ForMember(dest => dest.Text, opt => opt.Ignore());
 		CreateMap<ContentDto, Note>(MemberList.Source)
 			.ForMember(note => note.SourceText, opt => opt.MapFrom(dto => dto.Text))
-			.ForMember(note => note.SourceContentType, opt => opt.MapFrom((dto) => dto.ContentType ?? "text/plain"))
+			.ForMember(note => note.SourceContentType, opt => opt.MapFrom((dto) => dto.SourceContentType ?? Content.PlainTextMediaType))
 			.ForMember(note => note.Html, opt => opt.MapFrom(dto => dto.Text))
+			.ForSourceMember(src => src.SourceContentType, opt => opt.DoNotValidate())
 			.ForSourceMember(src => src.Type, opt => opt.DoNotValidate());
 		CreateMap<ContentDto, Content>(MemberList.None)
 			.ConstructUsing((dto, ctx) =>

--- a/Letterbook.Core/Models/Note.cs
+++ b/Letterbook.Core/Models/Note.cs
@@ -23,10 +23,11 @@ public class Note : Content
 
 	public override void Sanitize(IEnumerable<IContentSanitizer> sanitizers)
 	{
-		if (sanitizers.FirstOrDefault(s => s.ContentType.MediaType == ContentType?.MediaType) is { } sanitizer)
-			Html = sanitizer.Sanitize(Html, FediId.Authority);
-		else
-			throw CoreException.InvalidRequest("Unknown media type", "ContentType", ContentType?.MediaType ?? "unknown");
+		var (text, type) = SourceText != null && SourceContentType != null ? (SourceText, SourceContentType) : (Html, ContentType);
+		var sanitizer = sanitizers.FirstOrDefault(s => s.ContentType.MediaType == type.MediaType)
+		                ?? throw CoreException.InvalidRequest("Unknown media type", "ContentType", ContentType?.MediaType ?? "unknown");
+		Html = sanitizer.Sanitize(text, FediId.Authority);
+		ContentType = sanitizer.Result;
 	}
 
 	public override void UpdateFrom(Content content)

--- a/Letterbook.Core/Models/Note.cs
+++ b/Letterbook.Core/Models/Note.cs
@@ -1,4 +1,5 @@
 using System.Net.Mime;
+using Letterbook.Core.Exceptions;
 
 namespace Letterbook.Core.Models;
 
@@ -20,10 +21,12 @@ public class Note : Content
 		return Preview;
 	}
 
-	// TODO: proper sanitization
-	public override void Sanitize()
+	public override void Sanitize(IEnumerable<IContentSanitizer> sanitizers)
 	{
-		Html = SourceText ?? "";
+		if (sanitizers.FirstOrDefault(s => s.ContentType.MediaType == ContentType?.MediaType) is { } sanitizer)
+			Html = sanitizer.Sanitize(Html, FediId.Authority);
+		else
+			throw CoreException.InvalidRequest("Unknown media type", "ContentType", ContentType?.MediaType ?? "unknown");
 	}
 
 	public override void UpdateFrom(Content content)

--- a/Letterbook.Core/PostService.cs
+++ b/Letterbook.Core/PostService.cs
@@ -135,6 +135,11 @@ public class PostService : IAuthzPostService, IPostService
 		if (published) previous.UpdatedDate = DateTimeOffset.UtcNow;
 		else previous.CreatedDate = DateTimeOffset.UtcNow;
 
+		foreach (var content in previous.Contents)
+		{
+			content.Sanitize(_sanitizers);
+		}
+
 
 		_posts.Update(previous);
 		await _posts.Commit();
@@ -176,6 +181,7 @@ public class PostService : IAuthzPostService, IPostService
 		if (!post.FediId.HasLocalAuthority(_options))
 			throw CoreException.WrongAuthority("Can't modify contents of remote post", post.FediId);
 		content.SortKey ??= (post.Contents.Select(c => c.SortKey).Max() ?? -1) + 1;
+		content.Sanitize(_sanitizers);
 		post.Contents.Add(content);
 
 		if (post.PublishedDate is not null)
@@ -235,10 +241,7 @@ public class PostService : IAuthzPostService, IPostService
 		}
 
 		original.UpdateFrom(content);
-		// _posts.Update(content);
-		// post.Contents.Remove(content);
-		// post.AddContent(content);
-		// post.Contents.Add(content);
+		original.Sanitize(_sanitizers);
 
 		if (post.PublishedDate is not null)
 		{

--- a/Letterbook.Core/PostService.cs
+++ b/Letterbook.Core/PostService.cs
@@ -23,16 +23,18 @@ public class PostService : IAuthzPostService, IPostService
 	private readonly IPostAdapter _posts;
 	private readonly IPostEventPublisher _postEventPublisher;
 	private readonly IActivityPubClient _apClient;
+	private readonly IEnumerable<IContentSanitizer> _sanitizers;
 	private Uuid7 _profileId;
 	private IEnumerable<Claim> _claims = null!;
 
 	public PostService(ILogger<PostService> logger, IOptions<CoreOptions> options,
-		IPostAdapter posts, IPostEventPublisher postEventPublisher, IActivityPubClient apClient)
+		IPostAdapter posts, IPostEventPublisher postEventPublisher, IActivityPubClient apClient, IEnumerable<IContentSanitizer> sanitizers)
 	{
 		_logger = logger;
 		_posts = posts;
 		_postEventPublisher = postEventPublisher;
 		_apClient = apClient;
+		_sanitizers = sanitizers;
 		_options = options.Value;
 	}
 
@@ -60,8 +62,6 @@ public class PostService : IAuthzPostService, IPostService
 		return await _posts.LookupThread(threadId);
 	}
 
-	// TODO: generate HTML from source
-	// also content types
 	public async Task<Post> DraftNote(Uuid7 authorId, string contentSource, Uuid7? inReplyToId = default)
 	{
 		var author = await _posts.LookupProfile(authorId)
@@ -70,7 +70,7 @@ public class PostService : IAuthzPostService, IPostService
 		var note = new Note
 		{
 			SourceText = contentSource,
-			SourceContentType = new ContentType("text/plain"),
+			SourceContentType = new ContentType(Content.PlainTextMediaType),
 			Post = post,
 			FediId = default!,
 			Html = contentSource
@@ -99,6 +99,10 @@ public class PostService : IAuthzPostService, IPostService
 			throw CoreException.MissingData<Profile>($"Couldn't find profile {_profileId}", _profileId);
 		post.Creators.Clear();
 		post.Creators.Add(author);
+		foreach (var content in post.Contents)
+		{
+			content.Sanitize(_sanitizers);
+		}
 
 		if (publish) post.PublishedDate = DateTimeOffset.UtcNow;
 		_posts.Add(post);

--- a/Letterbook.Core/TextSanitizer.cs
+++ b/Letterbook.Core/TextSanitizer.cs
@@ -1,0 +1,11 @@
+using System.Net.Mime;
+using System.Web;
+using Letterbook.Core.Models;
+
+namespace Letterbook.Core;
+
+public class TextSanitizer : IContentSanitizer
+{
+	public string Sanitize(string content, string baseUrl = "") => HttpUtility.HtmlEncode(content);
+	public ContentType ContentType { get; } = new(Content.PlainTextMediaType);
+}

--- a/Letterbook.Core/TextSanitizer.cs
+++ b/Letterbook.Core/TextSanitizer.cs
@@ -8,4 +8,5 @@ public class TextSanitizer : IContentSanitizer
 {
 	public string Sanitize(string content, string baseUrl = "") => HttpUtility.HtmlEncode(content);
 	public ContentType ContentType { get; } = new(Content.PlainTextMediaType);
+	public ContentType Result { get; } = new(Content.HtmlMediaType);
 }

--- a/docs/OpenApi/letterbook-v1.json
+++ b/docs/OpenApi/letterbook-v1.json
@@ -1718,7 +1718,7 @@
             "type": "string",
             "nullable": true
           },
-          "contentType": {
+          "sourceContentType": {
             "type": "string",
             "nullable": true
           }


### PR DESCRIPTION
Adds content type-aware sanitization, and sanitizes posts along all create/update paths

Also, note the migration. When adding migrations, sometimes you need to help them out a little. Dotnet-ef will give a message like:
```shell
$ dotnet ef migrations add ContentTypeRequired
Build started...
Build succeeded.
An operation was scaffolded that may result in the loss of data. Please review the migration for accuracy.
Done. To undo this action, use 'ef migrations remove'
```

In this case, it was due to adding a NOT NULL constraint on the `ContentType` column. We can easily provide a default, using the `migrationBuilder`. This is something I want to get better about doing. In the past, I've just blown away migrations and started over, but the time is coming when that's not an option any more. So, consider this practice.

## Details
- html and plain text content types currently implemented
  - markdown would be an easy addition, on the backend
  - others are possible, MathML, perhaps

## Related
- closes #303