### PR TITLE
fix: serializable claims

### DIFF
--- a/Letterbook.Workers/Consumers/DeliveryWorker.cs
+++ b/Letterbook.Workers/Consumers/DeliveryWorker.cs
@@ -3,6 +3,7 @@ using Letterbook.Core.Adapters;
 using Letterbook.Core.Models;
 using Letterbook.Workers.Contracts;
 using MassTransit;
+using Claim = System.Security.Claims.Claim;
 
 namespace Letterbook.Workers.Consumers;
 
@@ -26,7 +27,7 @@ public class DeliveryWorker : IConsumer<ActivityMessage>
 	{
 		Profile? profile = default;
 		if (context.Message.OnBehalfOf is { } id)
-			profile = await _profiles.As(context.Message.Claims).LookupProfile(id);
+			profile = await _profiles.As(context.Message.Claims.Select(c => (Claim)c)).LookupProfile(id);
 		else
 			_logger.LogInformation("Sending {Activity} anonymously to {Inbox}", context.Message.Activity, context.Message.Inbox);
 

--- a/Letterbook.Workers/Consumers/DeliveryWorker.cs
+++ b/Letterbook.Workers/Consumers/DeliveryWorker.cs
@@ -27,7 +27,7 @@ public class DeliveryWorker : IConsumer<ActivityMessage>
 	{
 		Profile? profile = default;
 		if (context.Message.OnBehalfOf is { } id)
-			profile = await _profiles.As(context.Message.Claims.Select(c => (Claim)c)).LookupProfile(id);
+			profile = await _profiles.As(context.Message.Claims.Select(Extensions.MapClaim)).LookupProfile(id);
 		else
 			_logger.LogInformation("Sending {Activity} anonymously to {Inbox}", context.Message.Activity, context.Message.Inbox);
 

--- a/Letterbook.Workers/Consumers/TimelineConsumer.cs
+++ b/Letterbook.Workers/Consumers/TimelineConsumer.cs
@@ -34,30 +34,30 @@ namespace Letterbook.Workers.Consumers
 				case nameof(PostEventPublisher.Created):
 					return;
 				case nameof(PostEventPublisher.Deleted):
-					await _timelines.As(context.Message.Claims.Select(c => (Claim)c)).HandleDelete(post);
+					await _timelines.As(context.Message.Claims.Select(Extensions.MapClaim)).HandleDelete(post);
 					return;
 				case nameof(PostEventPublisher.Updated):
 					if (post.PublishedDate is null) return;
 					if (context.Message.PrevData is not null)
 					{
 						var prev = _mapper.Map<Post>(context.Message.NextData);
-						await _timelines.As(context.Message.Claims.Select(c => (Claim)c)).HandleUpdate(post, prev);
+						await _timelines.As(context.Message.Claims.Select(Extensions.MapClaim)).HandleUpdate(post, prev);
 					}
 					else
 						_logger.LogError("Couldn't update Post {PostId} in timeline due to unknown previous state", post.GetId25());
 
 					return;
 				case nameof(PostEventPublisher.Published):
-					await _timelines.As(context.Message.Claims.Select(c => (Claim)c)).HandlePublish(post);
+					await _timelines.As(context.Message.Claims.Select(Extensions.MapClaim)).HandlePublish(post);
 					return;
 				case nameof(PostEventPublisher.Liked):
 					return;
 				case nameof(PostEventPublisher.Shared):
 					_logger.LogDebug("Sender: {Id}", context.Message.Sender);
 					if (context.Message.Sender is { } senderId
-					    && await _profiles.As(context.Message.Claims.Select(c => (Claim)c)).LookupProfile(senderId) is { } sender)
+					    && await _profiles.As(context.Message.Claims.Select(Extensions.MapClaim)).LookupProfile(senderId) is { } sender)
 					{
-						await _timelines.As(context.Message.Claims.Select(c => (Claim)c)).HandleShare(post, sender);
+						await _timelines.As(context.Message.Claims.Select(Extensions.MapClaim)).HandleShare(post, sender);
 					}
 					else
 						_logger.LogError("Couldn't add shared Post {PostId} to timeline due to missing sender info for {ProfileId}",

--- a/Letterbook.Workers/Contracts/AccountEvent.cs
+++ b/Letterbook.Workers/Contracts/AccountEvent.cs
@@ -10,5 +10,5 @@ public record AccountEvent
 	public Account? PrevData { get; init; }
 	public required string Subject { get; init; }
 	public required string Type { get; init; }
-	public required ImmutableHashSet<Claim> Claims { get; init; }
+	public required Claim[] Claims { get; init; }
 }

--- a/Letterbook.Workers/Contracts/ActivityMessage.cs
+++ b/Letterbook.Workers/Contracts/ActivityMessage.cs
@@ -11,5 +11,5 @@ public record ActivityMessage
 	public required string Data { get; init; }
 	public required string Activity { get; init; }
 	public required string Type { get; init; }
-	public required ImmutableHashSet<Claim> Claims { get; init; }
+	public required Claim[] Claims { get; init; }
 }

--- a/Letterbook.Workers/Contracts/Claim.cs
+++ b/Letterbook.Workers/Contracts/Claim.cs
@@ -1,0 +1,24 @@
+using OpenIddict.Abstractions;
+using Claims = System.Security.Claims;
+
+namespace Letterbook.Workers.Contracts;
+
+/// <summary>
+/// A DTO for Claims
+/// </summary>
+public class Claim
+{
+	public required string Type { get; init; }
+	public required string Value { get; init; }
+	public string? ValueType { get; init; }
+	public string? Issuer { get; init; }
+
+	public static implicit operator Claims.Claim(Claim claim) => new(claim.Type, claim.Value, claim.ValueType, claim.Issuer);
+	public static implicit operator Claim(Claims.Claim claim) => new()
+	{
+		Type = claim.Type,
+		Value = claim.Value,
+		ValueType = claim.ValueType,
+		Issuer = claim.Issuer
+	};
+}

--- a/Letterbook.Workers/Contracts/PostEvent.cs
+++ b/Letterbook.Workers/Contracts/PostEvent.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Immutable;
-using System.Security.Claims;
-using Letterbook.Core.Models;
-using Letterbook.Core.Models.Dto;
+﻿using Letterbook.Core.Models.Dto;
 using Medo;
 
 namespace Letterbook.Workers.Contracts;

--- a/Letterbook.Workers/Extensions.cs
+++ b/Letterbook.Workers/Extensions.cs
@@ -1,0 +1,8 @@
+using System.Security.Claims;
+
+namespace Letterbook.Workers;
+
+public static class Extensions
+{
+	public static Claim MapClaim(Contracts.Claim c) => (Claim)c;
+}

--- a/Letterbook.Workers/Publishers/AccountEventPublisher.cs
+++ b/Letterbook.Workers/Publishers/AccountEventPublisher.cs
@@ -6,6 +6,7 @@ using Letterbook.Core.Models;
 using Letterbook.Workers.Contracts;
 using MassTransit;
 using Microsoft.Extensions.Options;
+using Claim = System.Security.Claims.Claim;
 
 namespace Letterbook.Workers.Publishers;
 
@@ -57,7 +58,7 @@ public class AccountEventPublisher : IAccountEventPublisher
 		return new AccountEvent
 		{
 			Subject = nextValue.Id.ToString(),
-			Claims = claims.ToImmutableHashSet(),
+			Claims = claims.Select(c => (Contracts.Claim)c).ToArray(),
 			Type = action,
 			NextData = nextValue,
 			PrevData = prevValue

--- a/Letterbook.Workers/Publishers/PostEventPublisher.cs
+++ b/Letterbook.Workers/Publishers/PostEventPublisher.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Immutable;
-using System.Security.Claims;
 using AutoMapper;
 using Letterbook.Core;
 using Letterbook.Core.Adapters;

--- a/Letterbook.Workers/Publishers/PostEventPublisher.cs
+++ b/Letterbook.Workers/Publishers/PostEventPublisher.cs
@@ -10,6 +10,7 @@ using Letterbook.Workers.Contracts;
 using MassTransit;
 using Medo;
 using Microsoft.Extensions.Options;
+using Claim = Letterbook.Workers.Contracts.Claim;
 using Profile = Letterbook.Core.Models.Profile;
 
 namespace Letterbook.Workers.Publishers;


### PR DESCRIPTION
Use a serializable claim DTO in worker contracts

## Details
- It turns out `System.Security.Claims.Claim` doesn't serialize to json; who knew :woman_shrugging: :sweat_smile: 

## Related
- prep for #191 
