### PR TITLE
feat: make authority a queryable field on Profiles

### DIFF
--- a/Letterbook.Adapter.Db/DataAdapter.cs
+++ b/Letterbook.Adapter.Db/DataAdapter.cs
@@ -239,6 +239,8 @@ public class DataAdapter : IDataAdapter, IAsyncDisposable
 
 	public void Update(Models.Post post) => _context.Posts.Update(post);
 
+	public void Update(Models.Audience audience) => _context.Update(audience);
+
 	public void UpdateRange(IEnumerable<Models.Profile> profile)
 	{
 		_context.Profiles.UpdateRange(profile);

--- a/Letterbook.Adapter.Db/EntityConfigs/ConfigureProfile.cs
+++ b/Letterbook.Adapter.Db/EntityConfigs/ConfigureProfile.cs
@@ -10,6 +10,7 @@ public class ConfigureProfile : IEntityTypeConfiguration<Models.Profile>
 		builder.Property(profile => profile.Id)
 			.ValueGeneratedNever();
 		builder.HasIndex(profile => profile.FediId);
+		builder.HasIndex(profile => profile.Authority);
 		builder.HasOne<Models.Account>(profile => profile.OwnedBy);
 		builder.Property(profile => profile.CustomFields).HasColumnType("jsonb");
 		builder.HasMany(profile => profile.Keys);

--- a/Letterbook.Adapter.Db/Migrations/20240916044339_AddProfileAuthority.Designer.cs
+++ b/Letterbook.Adapter.Db/Migrations/20240916044339_AddProfileAuthority.Designer.cs
@@ -5,6 +5,7 @@ using Letterbook.Adapter.Db;
 using Letterbook.Core.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Letterbook.Adapter.Db.Migrations
 {
     [DbContext(typeof(RelationalContext))]
-    partial class RelationalContextModelSnapshot : ModelSnapshot
+    [Migration("20240916044339_AddProfileAuthority")]
+    partial class AddProfileAuthority
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Letterbook.Adapter.Db/Migrations/20240916044339_AddProfileAuthority.cs
+++ b/Letterbook.Adapter.Db/Migrations/20240916044339_AddProfileAuthority.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Letterbook.Adapter.Db.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProfileAuthority : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Authority",
+                table: "Profiles",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Profiles_Authority",
+                table: "Profiles",
+                column: "Authority");
+
+            /**
+             * regex:
+             * \w+:\/\/				the scheme (ex. https://)
+             * (.*@)?				discarded capture group for the user info, just in case
+             * (\w+\.\w+[\.\w+]*)	capture group for the actual host name, which is what we want
+             * \/?.*				the port, path, query, and fragment portions
+             */
+            // \w+:\/\/(.*@)?(\w+\.\w+[\.\w+]*)\/?.*
+
+            // We have no servers, so no valuable data. So, we can probably skip this if necessary.
+            // But, this migration would actually leave existing profiles in a bad state.
+            // What we would need to do is extract, tokenize, reverse, and recombine the domain from the profile's
+            // fediId as part of the migration.
+            // Which is a _challenge_ to do in SQL.
+            // migrationBuilder.Sql(
+	            // """
+	            // UPDATE "Profiles" p
+	            // SET Authority=(SELECT "FediId" FROM "Profiles" p2 WHERE p2."Id"=p."Id")
+	            // """
+            // );
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Profiles_Authority",
+                table: "Profiles");
+
+            migrationBuilder.DropColumn(
+                name: "Authority",
+                table: "Profiles");
+        }
+    }
+}

--- a/Letterbook.Adapter.Db/Migrations/20240916044339_AddProfileAuthority.cs
+++ b/Letterbook.Adapter.Db/Migrations/20240916044339_AddProfileAuthority.cs
@@ -22,26 +22,36 @@ namespace Letterbook.Adapter.Db.Migrations
                 table: "Profiles",
                 column: "Authority");
 
+            migrationBuilder.Sql(
+				"""
+				CREATE OR REPLACE FUNCTION array_reverse(anyarray) RETURNS anyarray AS $$
+				SELECT ARRAY(
+					SELECT $1[i]
+					FROM generate_subscripts($1,1) AS s(i)
+					ORDER BY i DESC
+				);
+				$$ LANGUAGE 'sql' STRICT IMMUTABLE;
+				""");
+
             /**
              * regex:
              * \w+:\/\/				the scheme (ex. https://)
              * (.*@)?				discarded capture group for the user info, just in case
-             * (\w+\.\w+[\.\w+]*)	capture group for the actual host name, which is what we want
+             * (\w+[\.\w+]*)		capture group for the actual host name, which is what we want
              * \/?.*				the port, path, query, and fragment portions
              */
-            // \w+:\/\/(.*@)?(\w+\.\w+[\.\w+]*)\/?.*
-
-            // We have no servers, so no valuable data. So, we can probably skip this if necessary.
-            // But, this migration would actually leave existing profiles in a bad state.
-            // What we would need to do is extract, tokenize, reverse, and recombine the domain from the profile's
-            // fediId as part of the migration.
-            // Which is a _challenge_ to do in SQL.
-            // migrationBuilder.Sql(
-	            // """
-	            // UPDATE "Profiles" p
-	            // SET Authority=(SELECT "FediId" FROM "Profiles" p2 WHERE p2."Id"=p."Id")
-	            // """
-            // );
+            // \w+:\/\/(.*@)?(\w+[\.\w+]*)\/?.*
+            migrationBuilder.Sql(
+				"""
+				UPDATE "Profiles" p
+				SET "Authority"=(
+					SELECT array_to_string(array_reverse(string_to_array(regexp_replace(p2."FediId", '\w+:\/\/(.*@)?(\w+[\.\w+]*)\/?.*', '\2'), '.')), '.')
+					FROM "Profiles" p2
+					WHERE p2."Id"=p."Id"
+				)
+				WHERE p."Authority" = '';
+				"""
+            );
         }
 
         /// <inheritdoc />

--- a/Letterbook.Core.Tests/Fakes/FakePost.cs
+++ b/Letterbook.Core.Tests/Fakes/FakePost.cs
@@ -25,7 +25,7 @@ public class FakePost : Faker<Post>
 	public FakePost(IEnumerable<Profile> creators, int contents, CoreOptions? opts)
 	{
 		_creators = creators;
-		_authority = _creators.First().Authority;
+		_authority = _creators.First().FediId.Authority;
 		RuleFor(p => p.Id, faker => faker.Random.Guid7());
 		RuleFor(p => p.FediId, faker => faker.FediId(_authority, "post"));
 		RuleFor(p => p.Creators, () => _creators);
@@ -41,7 +41,7 @@ public class FakePost : Faker<Post>
 		RuleFor(p => p.Hostname, (_, post) => post.FediId.Host);
 		RuleFor(p => p.Audience, (faker, post) =>
 		{
-			var audience = post.Creators.Select(Audience.Followers);
+			var audience = post.Creators.SelectMany(c => c.Headlining);
 			if (faker.Random.Bool())
 				audience = audience.Append(Audience.Public);
 

--- a/Letterbook.Core.Tests/Fakes/FakeProfile.cs
+++ b/Letterbook.Core.Tests/Fakes/FakeProfile.cs
@@ -117,6 +117,7 @@ public sealed class FakeProfile : Faker<Profile>
 					Label = "Static test key"
 				}
 			});
+		RuleFor(p => p.Headlining, (faker, profile) => new List<Audience>() { Audience.Followers(profile) });
 	}
 
 	public FakeProfile(Uri uri, Account owner) : this(uri)

--- a/Letterbook.Core/Extensions/CoreOptionsExtensions.cs
+++ b/Letterbook.Core/Extensions/CoreOptionsExtensions.cs
@@ -8,7 +8,7 @@ public static class CoreOptionsExtensions
 		core.BaseUri().Authority == id.Authority;
 
 	public static bool HasLocalAuthority(this IFederated subject, CoreOptions core) =>
-		core.BaseUri().Authority == subject.Authority;
+		core.BaseUri().Authority == subject.FediId.Authority;
 
 	public static bool HasLocalAuthority(this CoreOptions coreOptions, string domain) =>
 		coreOptions.BaseUri().Authority == domain;

--- a/Letterbook.Core/Models/Profile.cs
+++ b/Letterbook.Core/Models/Profile.cs
@@ -19,6 +19,7 @@ public class Profile : IFederatedActor, IEquatable<Profile>
 	private Profile()
 	{
 		FediId = default!;
+		Authority = default!;
 		Inbox = default!;
 		Outbox = default!;
 		Followers = default!;
@@ -34,6 +35,7 @@ public class Profile : IFederatedActor, IEquatable<Profile>
 	{
 		_id = Uuid7.NewUuid7();
 		FediId = new Uri(baseUri, $"/actor/{_id.ToId25String()}");
+		Authority = FediId.GetAuthority();
 		Handle = string.Empty;
 		DisplayName = string.Empty;
 		Description = string.Empty;
@@ -75,7 +77,7 @@ public class Profile : IFederatedActor, IEquatable<Profile>
 	public Uri? SharedInbox { get; set; }
 	public Uri Followers { get; set; }
 	public Uri Following { get; set; }
-	public string Authority => FediId.Authority;
+	public string Authority { get; private set; }
 	public string Handle { get; set; }
 	public string DisplayName { get; set; }
 	public string Description { get; set; }
@@ -193,7 +195,8 @@ public class Profile : IFederatedActor, IEquatable<Profile>
 		return new Profile()
 		{
 			_id = Uuid7.NewUuid7(),
-			FediId = id
+			FediId = id,
+			Authority = id.GetAuthority()
 		};
 	}
 


### PR DESCRIPTION
The Authority field is the hierarchically ordered domain name from the FediId. That is, like `tld.domain.subdomain`. This is useful for doing fast queries to match a domain and all of its subdomains and ports, or exact matches on the full hostname.

## Details
- It's not critical because we don't have any production DBs, yet, but I would like to make the migration populate the correct data, which requires doing lots of string manipulation directly in SQL
- I could use some help with that, if anyone does that sort of thing

## Related
- prep for #191 