### PR TITLE
fix: federated followers audience

### DIFF
--- a/Letterbook.Core.Tests/ProfileServiceTests.cs
+++ b/Letterbook.Core.Tests/ProfileServiceTests.cs
@@ -86,8 +86,8 @@ public class ProfileServiceTests : WithMocks
 		var expectedId = Uuid7.NewUuid7();
 		_profile.Id = expectedId;
 		_profile.DisplayName = new Faker().Internet.UserName();
-		DataAdapterMock.Setup(m => m.LookupProfile(It.Is<Uuid7>(given => given == expectedId)))
-			.ReturnsAsync(_profile);
+		var queryProfile = ((List<Profile>)[_profile]).BuildMock();
+		DataAdapterMock.Setup(m => m.SingleProfile(_profile.GetId())).Returns(queryProfile);
 
 		var actual = await _service.UpdateDisplayName(expectedId, "Test Name");
 
@@ -100,8 +100,8 @@ public class ProfileServiceTests : WithMocks
 	public async Task NoUpdateDisplayNameNotExists()
 	{
 		var expectedId = Uuid7.NewUuid7();
-		DataAdapterMock.Setup(m => m.LookupProfile(It.Is<Uuid7>(given => given == expectedId)))
-			.ReturnsAsync(default(Profile));
+		var queryProfile = ((List<Profile>)[]).BuildMock();
+		DataAdapterMock.Setup(m => m.SingleProfile(expectedId)).Returns(queryProfile);
 
 		await Assert.ThrowsAsync<CoreException>(() => _service.UpdateDisplayName(expectedId, "Test Name"));
 	}
@@ -109,10 +109,10 @@ public class ProfileServiceTests : WithMocks
 	[Fact(DisplayName = "Should not update the display name when the name is unchanged")]
 	public async Task NoUpdateDisplayNameUnchanged()
 	{
-		DataAdapterMock.Setup(m => m.LookupProfile(It.Is<Uuid7>(given => given == _profile.Id)))
-			.ReturnsAsync(_profile);
+		var queryProfile = ((List<Profile>)[_profile]).BuildMock();
+		DataAdapterMock.Setup(m => m.SingleProfile(_profile.GetId())).Returns(queryProfile);
 
-		var actual = await _service.UpdateDisplayName((Uuid7)_profile.Id!, _profile.DisplayName);
+		var actual = await _service.UpdateDisplayName(_profile.GetId(), _profile.DisplayName);
 
 		Assert.Null(actual.Updated);
 		Assert.Equal(_profile, actual.Original);
@@ -126,8 +126,8 @@ public class ProfileServiceTests : WithMocks
 		var expectedId = Uuid7.NewUuid7();
 		_profile.Id = expectedId;
 		_profile.DisplayName = new Faker().Internet.UserName();
-		DataAdapterMock.Setup(m => m.LookupProfile(It.Is<Uuid7>(given => given == expectedId)))
-			.ReturnsAsync(_profile);
+		var queryProfile = ((List<Profile>)[_profile]).BuildMock();
+		DataAdapterMock.Setup(m => m.SingleProfile(_profile.GetId())).Returns(queryProfile);
 
 		var actual = await _service.UpdateDescription(expectedId, "This is a test user bio");
 
@@ -139,8 +139,8 @@ public class ProfileServiceTests : WithMocks
 	public async Task NoUpdateBioNotExists()
 	{
 		var expectedId = Uuid7.NewUuid7();
-		DataAdapterMock.Setup(m => m.LookupProfile(It.Is<Uuid7>(given => given == expectedId)))
-			.ReturnsAsync(default(Profile));
+		var queryProfile = ((List<Profile>)[]).BuildMock();
+		DataAdapterMock.Setup(m => m.SingleProfile(expectedId)).Returns(queryProfile);
 
 		await Assert.ThrowsAsync<CoreException>(() =>
 			_service.UpdateDescription(expectedId, "This is a test user bio"));
@@ -149,10 +149,10 @@ public class ProfileServiceTests : WithMocks
 	[Fact(DisplayName = "Should not update the bio when it is unchanged")]
 	public async Task NoUpdateBioUnchanged()
 	{
-		DataAdapterMock.Setup(m => m.LookupProfile(It.Is<Uuid7>(given => given == _profile.Id)))
-			.ReturnsAsync(_profile);
+		var queryProfile = ((List<Profile>)[_profile]).BuildMock();
+		DataAdapterMock.Setup(m => m.SingleProfile(_profile.GetId())).Returns(queryProfile);
 
-		var actual = await _service.UpdateDescription((Uuid7)_profile.Id!, _profile.Description);
+		var actual = await _service.UpdateDescription(_profile.GetId(), _profile.Description);
 
 		Assert.Null(actual.Updated);
 		Assert.Equal(_profile, actual.Original);
@@ -163,8 +163,8 @@ public class ProfileServiceTests : WithMocks
 	[Fact(DisplayName = "Should insert new custom fields")]
 	public async Task InsertCustomField()
 	{
-		DataAdapterMock.Setup(m => m.LookupProfile(It.Is<Uuid7>(given => given == _profile.Id)))
-			.ReturnsAsync(_profile);
+		var queryProfile = ((List<Profile>)[_profile]).BuildMock();
+		DataAdapterMock.Setup(m => m.SingleProfile(_profile.GetId())).Returns(queryProfile);
 
 		var actual = await _service.InsertCustomField((Uuid7)_profile.Id!, 0, "test item", "test value");
 		// var (original, actual) = await _service.InsertCustomField((Uuid7)_profile.LocalId!, 0, "test item", "test value");
@@ -181,8 +181,8 @@ public class ProfileServiceTests : WithMocks
 	[Fact(DisplayName = "Should insert new custom fields at given index")]
 	public async Task InsertCustomFieldAtIndex()
 	{
-		DataAdapterMock.Setup(m => m.LookupProfile(It.Is<Uuid7>(given => given == _profile.Id)))
-			.ReturnsAsync(_profile);
+		var queryProfile = ((List<Profile>)[_profile]).BuildMock();
+		DataAdapterMock.Setup(m => m.SingleProfile(_profile.GetId())).Returns(queryProfile);
 
 		var actual = await _service.InsertCustomField((Uuid7)_profile.Id!, 1, "test item", "test value");
 		// var (original, actual) = await _service.InsertCustomField((Uuid7)_profile.LocalId!, 1, "test item", "test value");
@@ -199,20 +199,19 @@ public class ProfileServiceTests : WithMocks
 	[Fact(DisplayName = "Should not insert custom fields when the profile doesn't exist")]
 	public async Task NoInsertCustomField()
 	{
-		var expectedId = Uuid7.NewUuid7();
-		DataAdapterMock.Setup(m => m.LookupProfile(It.Is<Uuid7>(given => given == expectedId)))
-			.ReturnsAsync(default(Profile));
+		var queryProfile = ((List<Profile>)[]).BuildMock();
+		DataAdapterMock.Setup(m => m.SingleProfile(_profile.GetId())).Returns(queryProfile);
 
 		await Assert.ThrowsAsync<CoreException>(() =>
-			_service.InsertCustomField((Uuid7)_profile.Id!, 0, "test item", "test value"));
+			_service.InsertCustomField(_profile.GetId(), 0, "test item", "test value"));
 	}
 
 	[Fact(DisplayName = "Should not insert custom fields when the list is already full")]
 	public async Task NoInsertCustomFieldTooMany()
 	{
 		_profile.CustomFields = _profile.CustomFields.Append(new() { Label = "item2", Value = "value2" }).ToArray();
-		DataAdapterMock.Setup(m => m.LookupProfile(It.Is<Uuid7>(given => given == _profile.Id)))
-			.ReturnsAsync(_profile);
+		var queryProfile = ((List<Profile>)[_profile]).BuildMock();
+		DataAdapterMock.Setup(m => m.SingleProfile(_profile.GetId())).Returns(queryProfile);
 
 		await Assert.ThrowsAsync<CoreException>(() =>
 			_service.InsertCustomField((Uuid7)_profile.Id!, 0, "test item", "test value"));
@@ -221,8 +220,8 @@ public class ProfileServiceTests : WithMocks
 	[Fact(DisplayName = "Should update custom fields")]
 	public async Task UpdateCustomField()
 	{
-		DataAdapterMock.Setup(m => m.LookupProfile(It.Is<Uuid7>(given => given == _profile.Id)))
-			.ReturnsAsync(_profile);
+		var queryProfile = ((List<Profile>)[_profile]).BuildMock();
+		DataAdapterMock.Setup(m => m.SingleProfile(_profile.GetId())).Returns(queryProfile);
 
 		var actual = await _service.UpdateCustomField((Uuid7)_profile.Id!, 0, "test item", "test value");
 
@@ -235,8 +234,8 @@ public class ProfileServiceTests : WithMocks
 	[Fact(DisplayName = "Should delete custom fields")]
 	public async Task DeleteCustomField()
 	{
-		DataAdapterMock.Setup(m => m.LookupProfile(It.Is<Uuid7>(given => given == _profile.Id)))
-			.ReturnsAsync(_profile);
+		var queryProfile = ((List<Profile>)[_profile]).BuildMock();
+		DataAdapterMock.Setup(m => m.SingleProfile(_profile.GetId())).Returns(queryProfile);
 
 		var actual = await _service.RemoveCustomField((Uuid7)_profile.Id!, 0);
 
@@ -290,8 +289,10 @@ public class ProfileServiceTests : WithMocks
 	public async Task ReceiveFollowRequest()
 	{
 		var follower = new FakeProfile().Generate();
-		DataAdapterMock.Setup(m => m.LookupProfile(_profile.FediId)).ReturnsAsync(_profile);
-		DataAdapterMock.Setup(m => m.LookupProfile(follower.FediId)).ReturnsAsync(follower);
+		var queryProfile = ((List<Profile>)[_profile]).BuildMock();
+		var queryFollower = ((List<Profile>)[follower]).BuildMock();
+		DataAdapterMock.Setup(m => m.SingleProfile(_profile.FediId)).Returns(queryProfile);
+		DataAdapterMock.Setup(m => m.SingleProfile(follower.FediId)).Returns(queryFollower);
 
 		var actual = await _service.ReceiveFollowRequest(_profile.FediId, follower.FediId, null);
 

--- a/Letterbook.Core.Tests/ProfileServiceTests.cs
+++ b/Letterbook.Core.Tests/ProfileServiceTests.cs
@@ -30,8 +30,9 @@ public class ProfileServiceTests : WithMocks
 		_fakeProfile = new FakeProfile("letterbook.example");
 		CoreOptionsMock.Value.MaxCustomFields = 2;
 
-		_service = new ProfileService(Mock.Of<ILogger<ProfileService>>(), CoreOptionsMock, DataAdapterMock.Object,
-			Mock.Of<IProfileEventPublisher>(), ActivityPubClientMock.Object, Mock.Of<IHostSigningKeyProvider>(), ActivityPublisherMock.Object);
+		_service = new ProfileService(Mock.Of<ILogger<ProfileService>>(), CoreOptionsMock, Mock.Of<Instrumentation>(),
+			DataAdapterMock.Object, Mock.Of<IProfileEventPublisher>(), ActivityPubClientMock.Object, Mock.Of<IHostSigningKeyProvider>(),
+			ActivityPublisherMock.Object);
 		_profile = _fakeProfile.Generate();
 	}
 

--- a/Letterbook.Core/Models/Profile.cs
+++ b/Letterbook.Core/Models/Profile.cs
@@ -148,7 +148,7 @@ public class Profile : IFederatedActor, IEquatable<Profile>
 		joining.Add(Audience.Boosts(following));
 		foreach (var audience in joining.ReplaceFrom(following.Headlining))
 		{
-			following.Audiences.Add(audience);
+			Audiences.Add(audience);
 		}
 
 		return relation;

--- a/Letterbook.Core/Models/Profile.cs
+++ b/Letterbook.Core/Models/Profile.cs
@@ -140,6 +140,16 @@ public class Profile : IFederatedActor, IEquatable<Profile>
 		var relation = new FollowerRelation(this, following, state);
 		FollowingCollection.Add(relation);
 		following.FollowersCollection.Add(relation);
+
+		var joining = new HashSet<Audience>();
+
+		joining.Add(Audience.Followers(following));
+		joining.Add(Audience.Boosts(following));
+		foreach (var audience in joining.ReplaceFrom(following.Headlining))
+		{
+			following.Audiences.Add(audience);
+		}
+
 		return relation;
 	}
 

--- a/Letterbook.Core/Models/Profile.cs
+++ b/Letterbook.Core/Models/Profile.cs
@@ -141,6 +141,7 @@ public class Profile : IFederatedActor, IEquatable<Profile>
 		FollowingCollection.Add(relation);
 		following.FollowersCollection.Add(relation);
 
+		if (state != FollowState.Accepted) return relation;
 		var joining = new HashSet<Audience>();
 
 		joining.Add(Audience.Followers(following));

--- a/Letterbook.Core/ProfileService.cs
+++ b/Letterbook.Core/ProfileService.cs
@@ -223,14 +223,6 @@ public class ProfileService : IProfileService, IAuthzProfileService
 			// TODO(moderation): Check for blocks
 			// TODO(moderation): Check for requiresApproval
 			var relation = self.Follow(target, FollowState.Accepted);
-			var joining = new HashSet<Audience>();
-
-			joining.Add(subscribeOnly ? Audience.Subscribers(target) : Audience.Followers(target));
-			joining.Add(Audience.Boosts(target));
-			foreach (var audience in joining.ReplaceFrom(target.Headlining))
-			{
-				self.Audiences.Add(audience);
-			}
 
 			await _profiles.Commit();
 			return relation;
@@ -303,7 +295,7 @@ public class ProfileService : IProfileService, IAuthzProfileService
 
 	private async Task<FollowerRelation> ReceiveFollowRequest(Profile target, Profile follower, Uri? requestId)
 	{
-		var relation = target.AddFollower(follower, FollowState.Accepted);
+		var relation = follower.Follow(target, FollowState.Accepted);
 		await _profiles.Commit();
 
 		var actor = target;

--- a/Letterbook.Core/ProfileService.cs
+++ b/Letterbook.Core/ProfileService.cs
@@ -231,11 +231,8 @@ public class ProfileService : IProfileService, IAuthzProfileService
 		// TODO(moderation): Check for blocks
 		// TODO(moderation): Check for requiresApproval
 		await _activity.Follow(target.Inbox, target, self);
-
 		self.Follow(target, FollowState.Pending);
-		self.Audiences.Add(Audience.Followers(target));
-		self.Audiences.Add(Audience.Boosts(target));
-		self.Audiences = self.Audiences.ReplaceFrom(target.Headlining);
+
 		await _profiles.Commit();
 		return new FollowerRelation(self, target, FollowState.Pending);
 	}

--- a/Letterbook.Core/TimelineService.cs
+++ b/Letterbook.Core/TimelineService.cs
@@ -100,12 +100,6 @@ public class TimelineService : IAuthzTimelineService, ITimelineService
 		result.UnionWith(post.AddressedTo.Where(
 			m => m.Subject.HasLocalAuthority(_options)).Select(m => Audience.FromMention(m.Subject)));
 
-		// The "public audience" would be equivalent to Mastodon's federated global feed
-		// That's not the same thing as putting posts into follower's feeds.
-		// This ensures we include public posts in the followers audience in case the sender doesn't specify it
-		if (!result.Contains(Audience.Public)) return result;
-		result.UnionWith(post.Creators.Select(Audience.Followers));
-
 		return result;
 	}
 

--- a/Letterbook.IntegrationTests/DataAdapterTests.cs
+++ b/Letterbook.IntegrationTests/DataAdapterTests.cs
@@ -146,10 +146,12 @@ public sealed class DataAdapterTests : IClassFixture<HostFixture<DataAdapterTest
 	[Fact(DisplayName = "Query from profiles")]
 	public async Task QueryFromProfile()
 	{
-		var query = _adapter.QueryFrom(_profiles[0], profile => profile.Audiences);
+		// We used to check audience, but that's likely to change as more features and test scenarios are added
+		// Headlining is more stable
+		var query = _adapter.QueryFrom(_profiles[0], profile => profile.Headlining);
 		var actual = await query.ToListAsync();
 
-		Assert.Equal(7, actual.Count);
+		Assert.Equal(3, actual.Count);
 	}
 
 	[Trait("AccountProfileAdapter", "QueryFrom")]

--- a/Letterbook.IntegrationTests/DataAdapterTests.cs
+++ b/Letterbook.IntegrationTests/DataAdapterTests.cs
@@ -149,7 +149,7 @@ public sealed class DataAdapterTests : IClassFixture<HostFixture<DataAdapterTest
 		var query = _adapter.QueryFrom(_profiles[0], profile => profile.Audiences);
 		var actual = await query.ToListAsync();
 
-		Assert.Equal(5, actual.Count);
+		Assert.Equal(7, actual.Count);
 	}
 
 	[Trait("AccountProfileAdapter", "QueryFrom")]

--- a/Letterbook.Workers.Tests/DependencyInjection.cs
+++ b/Letterbook.Workers.Tests/DependencyInjection.cs
@@ -21,8 +21,9 @@ public static class DependencyInjection
 			.AddScoped<IProfileService>(_ => mocks.ProfileServiceMock.Object)
 			.AddScoped<IActivityMessagePublisher>(_ => mocks.ActivityPublisherMock.Object)
 			.AddScoped<IDataAdapter>(_ => mocks.DataAdapterMock.Object)
-			.AddSingleton<MappingConfigProvider>()
 			.AddScoped<IActivityPubDocument, Document>()
+			.AddSingleton<Instrumentation>()
+			.AddSingleton<MappingConfigProvider>()
 			.AddSingleton<IOptions<CoreOptions>>(mocks.CoreOptionsMock);
 	}
 


### PR DESCRIPTION
Fixes the audience membership when remote federated profiles follow a local profile

## Details
- Federated followers were added to the follower collection, but not the follower audience[^1]
  - That caused posts not to be sent to them, because they weren't in the audience
  - Obviously, that defeats the whole point
- Also adds substantial telemetry, which was useful to diagnose this problem
  - Now we have it for next time

## Related
- progress on #191 

[^1]: Why is there a follower collection separate from the follower audience? Following is functionally an authorization grant to join the follower audience and view posts sent to it. But, having that authorization isn't the same as using it. A profile could join or leave the audience at their discretion, in order to tailor the content of their home feed.