### PR TITLE
chore: fix dev workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,7 +177,7 @@ Tests can be run from the suggested test explorer extension.
 
 ### Using Jetbrains Rider and VisualStudio
 
-There are `launchSettings.json` targets configured in the repo. Open Letterbook.sln and then run the `Letterbook: http` configuration.
+There are `launchSettings.json` targets configured in the repo. Open Letterbook.sln and then run the `Letterbook: dev` profile.
 
 Tests can be run from the built-in test runner.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ dotnet user-secrets set "HostSecret" "$(openssl rand -base64 32)" --project Lett
 4. Run Letterbook (in watch mode)
 ```shell
 dotnet restore Letterbook.sln
-dotnet watch run --project Letterbook.Web
+dotnet watch run --project Letterbook --launch-profile dev
 ```
 
 5. Open the UI http://localhost:5127  

--- a/Letterbook.Docs/_blog/2024-12-26/officeHours.md
+++ b/Letterbook.Docs/_blog/2024-12-26/officeHours.md
@@ -6,7 +6,7 @@ authors:
 
 # Office Hours
 
-This is a very small update, to announce I'll be holding maintainer office hours December 26, 2024 at 12pm US Central time (6pm UTC). [Details on the calendar][office-hours-cal]. And you can use [this link to join the video call][jitsi].
+This is a very small update, to announce I'll be holding maintainer office hours December 27, 2024 at 12pm US Central time (6pm UTC). [Details on the calendar][office-hours-cal]. And you can use [this link to join the video call][jitsi].
 
 Between the holidays and some encroaching burnout, progress on Letterbook has been slow for the last month or two. But, I'm doing better, and I'd like to get back to it. So, join me, if you can!
 

--- a/Letterbook/Properties/launchSettings.json
+++ b/Letterbook/Properties/launchSettings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
-    "http": {
+    "dev": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,9 @@ services:
     ports:
       - "5433:5432"
     volumes:
-      - letterbook_ts_data:/var/lib/postgresql/data
+      - ts_data:/var/lib/postgresql/data
     restart: always
-  letterbook_db:
+  postgres:
     container_name: postgres
     image: postgres:16-alpine
     command:
@@ -29,13 +29,15 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - letterbook_db_data:/var/lib/postgresql/data
+      - db_data:/var/lib/postgresql/data
       - ./volumes/postgresql.conf:/etc/postgresql/postgresql.conf:z
-      - ./volumes/pg_hba.conf:/var/lib/postgresql/data/pg_hba.conf:z
+      - ./volumes/pg_hba.conf:/etc/postgresql/pg_hba.conf:z
     restart: always
 
   # Optional debug tools
   httpbin:
+    profiles:
+      - debug
     container_name: httpbin
     image: kennethreitz/httpbin
     ports:
@@ -44,13 +46,19 @@ services:
 
   # Optional Dashboarding and Observability Services 
   loki:
+    profiles:
+      - debug
+      - o11y
     container_name: loki
     image: grafana/loki:latest
     ports:
       - "3100:3100"
     restart: unless-stopped
     
-  grafana:    
+  grafana:
+    profiles:
+      - debug
+      - o11y
     depends_on:
       - loki
       - prometheus
@@ -64,6 +72,9 @@ services:
     restart: unless-stopped
     
   prometheus:
+    profiles:
+      - debug
+      - o11y
     container_name: prometheus
     image: prom/prometheus:v2.55.1
     ports:
@@ -73,6 +84,9 @@ services:
     restart: unless-stopped
     
   tempo:
+    profiles:
+      - debug
+      - o11y
     container_name: tempo
     image: &tempo-image grafana/tempo:2.6.1
     command: [ "-config.file=/etc/tempo.yaml" ]
@@ -80,13 +94,16 @@ services:
       - tempo-init
     volumes:
       - ./Letterbook.Dashboards/Tempo/tempo.yaml:/etc/tempo.yaml:z
-      - letterbook_tempo_data:/tmp/tempo
+      - tempo_data:/tmp/tempo
     ports:
       - "9095:9095" # tempo grpc
       - "4317:4317"  # otlp grpc
     restart: unless-stopped
 
   tempo-init:
+    profiles:
+      - debug
+      - o11y
     container_name: tempo-init
     image: *tempo-image
     user: root
@@ -95,9 +112,13 @@ services:
       - "10001:10001"
       - "/var/tempo"
     volumes:
-      - letterbook_tempo_data:/var/tempo
+      - tempo_data:/var/tempo
+    restart: no
 
   db_metrics_exporter:
+    profiles:
+      - debug
+      - o11y
     container_name: metrics_exporter
     image: prometheuscommunity/postgres-exporter
     depends_on:
@@ -110,9 +131,9 @@ services:
     restart: unless-stopped
 
 volumes:
-  letterbook_db_data:
+  db_data:
     driver: local
-  letterbook_ts_data:
+  ts_data:
     driver: local
-  letterbook_tempo_data:
+  tempo_data:
     driver: local

--- a/volumes/postgresql.conf
+++ b/volumes/postgresql.conf
@@ -41,7 +41,7 @@
 
 #data_directory = 'ConfigDir'		# use data in another directory
 					# (change requires restart)
-#hba_file = 'ConfigDir/pg_hba.conf'	# host-based authentication file
+hba_file = '/etc/postgresql/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
 #ident_file = 'ConfigDir/pg_ident.conf'	# ident configuration file
 					# (change requires restart)


### PR DESCRIPTION
Fixes the postgres config, and other updates to docker compose and contributing guide

## Details
- use compose profiles, to run only required services
- move pg_hba.conf, to permit first-run automatic db creation
- rename launch profile, for clarity
- update quickstart to use the preferred monolith project and dev launch profile