### PR TITLE
chore: renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,23 +1,50 @@
 ﻿{
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "ignoreDeps": ["Moq", "dotnet-sdk", "dotnet-runtime"],
+  "ignoreDeps": [
+    "Moq",
+    "dotnet-sdk",
+    "dotnet-runtime"
+  ],
   "packageRules": [
     {
-      "matchCategories": ["dotnet"],
+      "matchPackageNames": [
+        "Microsoft.Extensions**",
+        "Microsoft.EntityFramework**",
+        "Microsoft.AspNetCore**",
+        "System.Text.Json",
+        "Serilog**",
+        "Npgsql**"
+      ],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "matchCategories": [
+        "dotnet"
+      ],
       "groupName": "dotnet packages"
     },
     {
-      "matchCategories": ["github-actions", "docker"],
+      "matchCategories": [
+        "github-actions",
+        "docker"
+      ],
       "groupName": "dev dependencies"
     },
     {
-      "matchDepNames": ["dotnet-sdk", "dotnet-runtime"],
-      "updateTypes": ["patch"],
+      "matchDepNames": [
+        "dotnet-sdk",
+        "dotnet-runtime"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
       "enabled": false
     },
     {
-      "matchDepPrefixes": ["Microsoft.CodeAnalysis"],
-      "enabled": false
+      "enabled": false,
+      "matchDepNames": [
+        "Microsoft.CodeAnalysis{/,}**"
+      ]
     }
   ]
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,12 +19,12 @@
     <PackageVersion Include="Markdig" Version="0.39.1" />
     <PackageVersion Include="MassTransit" Version="8.3.4" />
     <PackageVersion Include="MassTransit.Abstractions" Version="8.3.4" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[8.0.11, 9.0.0)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="[8.0.11, 9.0.0)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="[8.0.11, 9.0.0)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="[8.0.11, 9.0.0)" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="[8.0.11, 9.0.0)" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.11, 9.0.0)" />
     <PackageVersion Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
@@ -35,29 +35,29 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="8.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.3.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.3.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="[8.0.11, 9.0.0)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="[8.0.11, 9.0.0)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="[8.0.11, 9.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[8.0.2, 9.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="[8.0.11, 9.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[8.0.1, 9.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="[8.0.11, 9.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="[8.0.11, 9.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="[8.0.1, 9.0.0)" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="[8.3.0, 9.0.0)" />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="[8.3.0, 9.0.0)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.49.0" />
     <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.49.0" />
-    <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.7" />
+    <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="[8.0.7, 9.0.0)" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
     <PackageVersion Include="MockQueryable.Moq" Version="7.0.3" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <!--  Neovolve 6.3+ requires an upgrade to various Microsoft.Abstractions 9.x, which we're not taking yet -->
     <PackageVersion Include="Neovolve.Logging.Xunit" Version="[6.2.0, 6.3.0)" />
-    <PackageVersion Include="Npgsql" Version="8.0.6" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
-    <PackageVersion Include="Npgsql.OpenTelemetry" Version="8.0.6" />
+    <PackageVersion Include="Npgsql" Version="[8.0.6, 9.0.0)" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="[8.0.11, 9.0.0)" />
+    <PackageVersion Include="Npgsql.OpenTelemetry" Version="[8.0.6, 9.0.0)" />
     <PackageVersion Include="NSign.Abstractions" Version="1.1.1" />
     <PackageVersion Include="NSign.AspNetCore" Version="1.1.1" />
     <PackageVersion Include="NSign.Client" Version="1.1.1" />
@@ -79,14 +79,14 @@
     <PackageVersion Include="RazorLight" Version="2.3.1" />
     <PackageVersion Include="Request.Body.Peeker" Version="1.3.0" />
     <PackageVersion Include="Serilog" Version="4.2.0" />
-    <PackageVersion Include="Serilog.AspNetCore" Version="8.0.3" />
+    <PackageVersion Include="Serilog.AspNetCore" Version="[8.0.3, 9.0.0)" />
     <PackageVersion Include="Serilog.Enrichers.Span" Version="3.1.0" />
     <PackageVersion Include="Serilog.Expressions" Version="5.0.0" />
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="8.0.0" />
-    <PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.4" />
+    <PackageVersion Include="Serilog.Extensions.Hosting" Version="[8.0.0, 9.0.0)" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="[8.0.4, 9.0.0)" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageVersion Include="Serilog.Sinks.Grafana.Loki" Version="8.3.0" />
+    <PackageVersion Include="Serilog.Sinks.Grafana.Loki" Version="[8.3.0, 9.0.0)" />
     <PackageVersion Include="ServiceStack" Version="8.5.2" />
     <PackageVersion Include="ServiceStack.Mvc" Version="8.5.2" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.9.0" />


### PR DESCRIPTION
don't update packages that require dotnet 9x