### PR TITLE
Fix building in Visual Studio by targeting multiple frameworks in Letterbook.Generators

### DIFF
--- a/Letterbook.Core/Letterbook.Core.csproj
+++ b/Letterbook.Core/Letterbook.Core.csproj
@@ -35,8 +35,14 @@
       <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
     </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Letterbook.Generators\Letterbook.Generators\Letterbook.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true"/>
+    <ItemGroup Condition="'$(MSBuildRuntimeType)' != 'Full'"> <!-- Building using dotnet tooling. -->
+      <ProjectReference Include="..\Letterbook.Generators\Letterbook.Generators\Letterbook.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" SetTargetFramework="TargetFramework=$(TargetFramework)" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(MSBuildRuntimeType)' == 'Full'"> <!-- Building inside Visual Studio. -->
+      <!-- Letterbook.Generators must be built for netstandard2.0 for its generators and analyzers to be usable inside Visual Studio -->
+      <ProjectReference Include="..\Letterbook.Generators\Letterbook.Generators\Letterbook.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" SetTargetFramework="TargetFramework=netstandard2.0" />
+      <!-- Letterbook.Generators must be built targeting the same framework as this project to allow the use of runtime features such as static abstract members on interfaces -->
+      <ProjectReference Include="..\Letterbook.Generators\Letterbook.Generators\Letterbook.Generators.csproj" ReferenceOutputAssembly="true" SetTargetFramework="TargetFramework=$(TargetFramework)" />
     </ItemGroup>
 
 </Project>

--- a/Letterbook.Generators/Letterbook.Generators/ITypedId.cs
+++ b/Letterbook.Generators/Letterbook.Generators/ITypedId.cs
@@ -3,5 +3,8 @@ namespace Letterbook.Generators;
 public interface ITypedId<T>
 {
 	T Id { get; set; }
+
+#if NET // netstandard2.0 doesn't support static abstract members in interfaces, so only include this when building for use at runtime
 	static abstract T FromString(string s);
+#endif
 }

--- a/Letterbook.Generators/Letterbook.Generators/Letterbook.Generators.csproj
+++ b/Letterbook.Generators/Letterbook.Generators/Letterbook.Generators.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
         <IsPackable>false</IsPackable>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>


### PR DESCRIPTION
Visual Studio can't load code generators & analyzers that target net8.0 (https://github.com/dotnet/roslyn/issues/47087, https://github.com/dotnet/roslyn-analyzers/issues/7302).
With this change, `Letterbook.Generators` will now be built twice, targeting both `netstandard2.0` and `net8.0`, and the `netstandard2.0` build will be referenced when building inside of Visual Studio.

To validate this change, I built the solution with Visual Studio and dotnet on a x64 windows machine. I ran all the tests in VS and they passed, excluding `Letterbook.IntegrationTests` and `Letterbook.Web.Tests.E2E` which failed and I assume will need additional setup.

## Details
- `Letterbook.Core`'s reference to `Letterbook.Generators` is unfortunately significantly more complex now.
  - When building inside VS, it's referenced *twice*; the `netstandard2.0` version is used for source generation, and the `net8.0` version is the assembly that's actually referenced by `Letterbook.Core`.
  - When building outside of VS, it only references the `net8.0` version, which is the same behavior as before.
- When building `Letterbook.Generators` targeting `netstandard2.0`, `ITypedId<T>.FromString` is not built since there's no runtime support for `static abstract` members in interfaces; fortunately it's not needed during source generation time.
- I tried a couple alternatives that had a larger footprint and felt messier:
  - Moving `ITypedId<T>` into `Letterbook.Core`, this would either require changing namespaces or introducing an inconsistency by having a type in the `Letterbook.Generators` namespace living in the `Letterbook.Core` project.
  - Specifically including `ITypedId.cs` from `Letterbook.Generators` in `Letterbook.Core.csproj`. Since this depended on `.cs` file paths it felt unacceptably brittle.

## Related
- Fixes #369
