### PR TITLE
fix: block and report migration

### DIFF
--- a/Letterbook.Adapter.Db/Migrations/20241209072037_FixIds.Designer.cs
+++ b/Letterbook.Adapter.Db/Migrations/20241209072037_FixIds.Designer.cs
@@ -14,7 +14,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Letterbook.Adapter.Db.Migrations
 {
     [DbContext(typeof(RelationalContext))]
-    [Migration("20241209072037_blah")]
+    [Migration("20241209072037_FixIds")]
     partial class FidIds
     {
         /// <inheritdoc />

--- a/Letterbook.Adapter.Db/Migrations/20250121062137_BlockAndReport.cs
+++ b/Letterbook.Adapter.Db/Migrations/20250121062137_BlockAndReport.cs
@@ -18,13 +18,18 @@ namespace Letterbook.Adapter.Db.Migrations
                 name: "Restrictions",
                 table: "Profiles",
                 type: "jsonb",
-                nullable: false);
+                nullable: false,
+                defaultValue: new Dictionary<Restrictions, DateTimeOffset>()
+                {
+	                [Restrictions.None] = new DateTimeOffset(new DateTime(2025, 2, 4, 16, 59, 41, 837, DateTimeKind.Unspecified).AddTicks(4925), new TimeSpan(0, 0, 0, 0, 0)),
+                });
 
             migrationBuilder.AddColumn<List<RelationCondition>>(
                 name: "Conditions",
                 table: "FollowerRelation",
                 type: "jsonb",
-                nullable: false);
+                nullable: false,
+                defaultValue: new List<RelationCondition>());
 
             migrationBuilder.CreateTable(
                 name: "ModerationPolicy",


### PR DESCRIPTION
added appropriate default values for new columns
