### PR TITLE
internals: Updated authorization interface

### DIFF
--- a/Letterbook.Api/Controllers/PostsController.cs
+++ b/Letterbook.Api/Controllers/PostsController.cs
@@ -61,10 +61,10 @@ public class PostsController : ControllerBase
 			content.SetLocalFediId(_options);
 		}
 
-		var decision = _authz.Create(User.Claims, post, profileId);
+		var decision = _authz.Create(User.Claims, post);
 		if (!decision.Allowed)
 			return Unauthorized(decision);
-		var pubDecision = _authz.Publish(User.Claims, post, profileId);
+		var pubDecision = _authz.Publish(User.Claims, post);
 		if (!draft && !pubDecision.Allowed)
 			return Unauthorized(pubDecision);
 
@@ -94,7 +94,7 @@ public class PostsController : ControllerBase
 		if (_mapper.Map<Post>(dto) is not { } post)
 			return BadRequest();
 
-		var decision = _authz.Publish(User.Claims, post, (Uuid7)profileId);
+		var decision = _authz.Publish(User.Claims, post);
 		if (!decision.Allowed)
 			return Unauthorized(decision);
 

--- a/Letterbook.Api/Controllers/ProfilesController.cs
+++ b/Letterbook.Api/Controllers/ProfilesController.cs
@@ -76,7 +76,7 @@ public class ProfilesController : ControllerBase
 		if (_mapper.Map<Models.Profile>(dto) is not { } profile)
 			return BadRequest(new ErrorMessage(ErrorCodes.InvalidRequest, $"Invalid {typeof(FullProfileDto)}"));
 
-		var decision = _authz.Update(User.Claims, profile, profileId);
+		var decision = _authz.Update(User.Claims, profile);
 		if (!decision.Allowed)
 			return Unauthorized(decision);
 

--- a/Letterbook.Core.Tests/WithMocks.cs
+++ b/Letterbook.Core.Tests/WithMocks.cs
@@ -83,20 +83,28 @@ public abstract class WithMocks
 		// TODO: reflect over the Decision methods instead of individual setups
 		AuthorizationServiceMock.Setup(s => s.View(It.IsAny<IEnumerable<Claim>>(), It.IsAny<object>()))
 			.Returns(Allow);
+		AuthorizationServiceMock.Setup(s => s.View<object>(It.IsAny<IEnumerable<Claim>>()))
+			.Returns(AllowNone);
 		AuthorizationServiceMock.Setup(s => s.Create(It.IsAny<IEnumerable<Claim>>(), It.IsAny<object>()))
 			.Returns(Allow);
+		AuthorizationServiceMock.Setup(s => s.Create<object>(It.IsAny<IEnumerable<Claim>>()))
+			.Returns(AllowNone);
 		AuthorizationServiceMock.Setup(s => s.Delete(It.IsAny<IEnumerable<Claim>>(), It.IsAny<object>()))
 			.Returns(Allow);
 		AuthorizationServiceMock.Setup(s => s.Publish(It.IsAny<IEnumerable<Claim>>(), It.IsAny<object>()))
 			.Returns(Allow);
 		AuthorizationServiceMock.Setup(s => s.Update(It.IsAny<IEnumerable<Claim>>(), It.IsAny<object>()))
 			.Returns(Allow);
-		AuthorizationServiceMock.Setup(s => s.Report(It.IsAny<IEnumerable<Claim>>()))
-			.Returns(Allow);
+		AuthorizationServiceMock.Setup(s => s.Update<object>(It.IsAny<IEnumerable<Claim>>()))
+			.Returns(AllowNone);
 		AuthorizationServiceMock.Setup(s => s.Attribute(It.IsAny<IEnumerable<Claim>>(), It.IsAny<object>(), It.IsAny<ProfileId>()))
+			.Returns(AllowProfile);
+		AuthorizationServiceMock.Setup(s => s.Any(It.IsAny<IEnumerable<Claim>>(), It.IsAny<ProfileId>()))
 			.Returns(Allow);
 		return;
 
-		Decision Allow(IEnumerable<Claim> claims, IFederated _, Uuid7 __) => Decision.Allow("Mock", claims);
+		Decision Allow(IEnumerable<Claim> claims, object _) => Decision.Allow("Mock", claims);
+		Decision AllowProfile(IEnumerable<Claim> claims, object _, ProfileId __) => Decision.Allow("Mock", claims);
+		Decision AllowNone(IEnumerable<Claim> claims) => Decision.Allow("Mock", claims);
 	}
 }

--- a/Letterbook.Core.Tests/WithMocks.cs
+++ b/Letterbook.Core.Tests/WithMocks.cs
@@ -81,17 +81,19 @@ public abstract class WithMocks
 	public void MockAuthorizeAllowAll()
 	{
 		// TODO: reflect over the Decision methods instead of individual setups
-		AuthorizationServiceMock.Setup(s => s.View(It.IsAny<IEnumerable<Claim>>(), It.IsAny<IFederated>(), It.IsAny<Uuid7>()))
+		AuthorizationServiceMock.Setup(s => s.View(It.IsAny<IEnumerable<Claim>>(), It.IsAny<object>()))
 			.Returns(Allow);
-		AuthorizationServiceMock.Setup(s => s.Create(It.IsAny<IEnumerable<Claim>>(), It.IsAny<IFederated>(), It.IsAny<Uuid7>()))
+		AuthorizationServiceMock.Setup(s => s.Create(It.IsAny<IEnumerable<Claim>>(), It.IsAny<object>()))
 			.Returns(Allow);
-		AuthorizationServiceMock.Setup(s => s.Delete(It.IsAny<IEnumerable<Claim>>(), It.IsAny<IFederated>(), It.IsAny<Uuid7>()))
+		AuthorizationServiceMock.Setup(s => s.Delete(It.IsAny<IEnumerable<Claim>>(), It.IsAny<object>()))
 			.Returns(Allow);
-		AuthorizationServiceMock.Setup(s => s.Publish(It.IsAny<IEnumerable<Claim>>(), It.IsAny<IFederated>(), It.IsAny<Uuid7>()))
+		AuthorizationServiceMock.Setup(s => s.Publish(It.IsAny<IEnumerable<Claim>>(), It.IsAny<object>()))
 			.Returns(Allow);
-		AuthorizationServiceMock.Setup(s => s.Update(It.IsAny<IEnumerable<Claim>>(), It.IsAny<IFederated>(), It.IsAny<Uuid7>()))
+		AuthorizationServiceMock.Setup(s => s.Update(It.IsAny<IEnumerable<Claim>>(), It.IsAny<object>()))
 			.Returns(Allow);
-		AuthorizationServiceMock.Setup(s => s.Report(It.IsAny<IEnumerable<Claim>>(), It.IsAny<IFederated>(), It.IsAny<Uuid7>()))
+		AuthorizationServiceMock.Setup(s => s.Report(It.IsAny<IEnumerable<Claim>>()))
+			.Returns(Allow);
+		AuthorizationServiceMock.Setup(s => s.Attribute(It.IsAny<IEnumerable<Claim>>(), It.IsAny<object>(), It.IsAny<ProfileId>()))
 			.Returns(Allow);
 		return;
 

--- a/Letterbook.Core/Authorization/AuthorizationService.cs
+++ b/Letterbook.Core/Authorization/AuthorizationService.cs
@@ -6,37 +6,37 @@ namespace Letterbook.Core.Authorization;
 
 public class AuthorizationService : IAuthorizationService
 {
-	public Decision Create<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated
+	public Decision Create<T>(IEnumerable<Claim> claims, T target)
 	{
 		return Decision.Allow("todo", claims);
 	}
 
-	public Decision Update<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated
+	public Decision Update<T>(IEnumerable<Claim> claims, T target)
 	{
 		return Decision.Allow("todo", claims);
 	}
 
-	public Decision Delete<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated
+	public Decision Delete<T>(IEnumerable<Claim> claims, T target)
 	{
 		return Decision.Allow("todo", claims);
 	}
 
-	public Decision Attribute<T>(IEnumerable<Claim> claims, T target, Uuid7 attributeTo, Uuid7 profile) where T : IFederated
+	public Decision Attribute<T>(IEnumerable<Claim> claims, T target, ProfileId attributeTo)
 	{
 		return Decision.Allow("todo", claims);
 	}
 
-	public Decision Publish<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated
+	public Decision Publish<T>(IEnumerable<Claim> claims, T target)
 	{
 		return Decision.Allow("todo", claims);
 	}
 
-	public Decision View<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated
+	public Decision View<T>(IEnumerable<Claim> claims, T target)
 	{
 		return Decision.Allow("todo", claims);
 	}
 
-	public Decision Report<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated
+	public Decision Report(IEnumerable<Claim> claims)
 	{
 		return Decision.Allow("todo", claims);
 	}

--- a/Letterbook.Core/Authorization/AuthorizationService.cs
+++ b/Letterbook.Core/Authorization/AuthorizationService.cs
@@ -11,7 +11,17 @@ public class AuthorizationService : IAuthorizationService
 		return Decision.Allow("todo", claims);
 	}
 
+	public Decision Create<T>(IEnumerable<Claim> claims)
+	{
+		return Decision.Allow("todo", claims);
+	}
+
 	public Decision Update<T>(IEnumerable<Claim> claims, T target)
+	{
+		return Decision.Allow("todo", claims);
+	}
+
+	public Decision Update<T>(IEnumerable<Claim> claims)
 	{
 		return Decision.Allow("todo", claims);
 	}
@@ -36,7 +46,12 @@ public class AuthorizationService : IAuthorizationService
 		return Decision.Allow("todo", claims);
 	}
 
-	public Decision Report(IEnumerable<Claim> claims)
+	public Decision View<T>(IEnumerable<Claim> claims)
+	{
+		return Decision.Allow("todo", claims);
+	}
+
+	public Decision Any(IEnumerable<Claim> claims, ProfileId profileId)
 	{
 		return Decision.Allow("todo", claims);
 	}

--- a/Letterbook.Core/IAuthorizationService.cs
+++ b/Letterbook.Core/IAuthorizationService.cs
@@ -7,20 +7,19 @@ namespace Letterbook.Core;
 public interface IAuthorizationService
 {
 	/// <summary>
-	/// Authorize creating reports
-	/// </summary>
-	/// <param name="claims"></param>
-	/// <returns></returns>
-	public Decision Report(IEnumerable<Claim> claims);
-
-	/// <summary>
-	/// Authorize creating a new resource
+	/// Authorize creating a specific resource
 	/// </summary>
 	/// <param name="claims"></param>
 	/// <param name="resource"></param>
 	/// <typeparam name="T"></typeparam>
 	/// <returns></returns>
 	public Decision Create<T>(IEnumerable<Claim> claims, T resource);
+
+	/// <summary>
+	/// Authorize creatine a new resource by type
+	/// </summary>
+	/// <see cref="Create{T}(System.Collections.Generic.IEnumerable{System.Security.Claims.Claim},T)"/>
+	public Decision Create<T>(IEnumerable<Claim> claims);
 
 	/// <summary>
 	/// Authorize modifying an existing resource
@@ -30,6 +29,12 @@ public interface IAuthorizationService
 	/// <typeparam name="T"></typeparam>
 	/// <returns></returns>
 	public Decision Update<T>(IEnumerable<Claim> claims, T resource);
+
+	/// <summary>
+	/// Authorize modifying a type of resource
+	/// </summary>
+	/// <see cref="Update{T}(System.Collections.Generic.IEnumerable{System.Security.Claims.Claim},T)"/>
+	public Decision Update<T>(IEnumerable<Claim> claims);
 
 	/// <summary>
 	/// Authorize deleting an existing resource
@@ -67,6 +72,19 @@ public interface IAuthorizationService
 	/// <typeparam name="T"></typeparam>
 	/// <returns></returns>
 	public Decision View<T>(IEnumerable<Claim> claims, T resource);
+
+	/// <summary>Authorize reading or viewing a type of resource</summary>
+	/// <see cref="View{T}(System.Collections.Generic.IEnumerable{System.Security.Claims.Claim},T)"/>
+	public Decision View<T>(IEnumerable<Claim> claims);
+
+	/// <summary>
+	/// Authorize at least one claim on the Profile. This supports early exit for requests that are definitely unauthorized. In most cases
+	/// some additional authorization will still be necessary.
+	/// </summary>
+	/// <param name="claims"></param>
+	/// <param name="profileId"></param>
+	/// <returns></returns>
+	public Decision Any(IEnumerable<Claim> claims, ProfileId profileId);
 
 	// TODO: collections/tags/whatever we call them
 	// TODO: account stuff

--- a/Letterbook.Core/IAuthorizationService.cs
+++ b/Letterbook.Core/IAuthorizationService.cs
@@ -1,19 +1,72 @@
 using System.Security.Claims;
 using Letterbook.Core.Authorization;
 using Letterbook.Core.Models;
-using Medo;
 
 namespace Letterbook.Core;
 
 public interface IAuthorizationService
 {
-	public Decision Create<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated;
-	public Decision Update<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated;
-	public Decision Delete<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated;
-	public Decision Attribute<T>(IEnumerable<Claim> claims, T target, Uuid7 attributeTo, Uuid7 profile) where T : IFederated;
-	public Decision Publish<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated;
-	public Decision View<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated;
-	public Decision Report<T>(IEnumerable<Claim> claims, T target, Uuid7 profile) where T : IFederated;
+	/// <summary>
+	/// Authorize creating reports
+	/// </summary>
+	/// <param name="claims"></param>
+	/// <returns></returns>
+	public Decision Report(IEnumerable<Claim> claims);
+
+	/// <summary>
+	/// Authorize creating a new resource
+	/// </summary>
+	/// <param name="claims"></param>
+	/// <param name="resource"></param>
+	/// <typeparam name="T"></typeparam>
+	/// <returns></returns>
+	public Decision Create<T>(IEnumerable<Claim> claims, T resource);
+
+	/// <summary>
+	/// Authorize modifying an existing resource
+	/// </summary>
+	/// <param name="claims"></param>
+	/// <param name="resource"></param>
+	/// <typeparam name="T"></typeparam>
+	/// <returns></returns>
+	public Decision Update<T>(IEnumerable<Claim> claims, T resource);
+
+	/// <summary>
+	/// Authorize deleting an existing resource
+	/// </summary>
+	/// <param name="claims"></param>
+	/// <param name="resource"></param>
+	/// <typeparam name="T"></typeparam>
+	/// <returns></returns>
+	public Decision Delete<T>(IEnumerable<Claim> claims, T resource);
+
+	/// <summary>
+	/// Authorize adding a creator to a resource
+	/// </summary>
+	/// <param name="claims"></param>
+	/// <param name="resource"></param>
+	/// <param name="attributeTo">The profile to add as creator</param>
+	/// <typeparam name="T"></typeparam>
+	/// <returns></returns>
+	public Decision Attribute<T>(IEnumerable<Claim> claims, T resource, ProfileId attributeTo);
+
+	/// <summary>
+	/// Authorize publishing a resource to its specified audience
+	/// </summary>
+	/// <param name="claims"></param>
+	/// <param name="resource"></param>
+	/// <typeparam name="T"></typeparam>
+	/// <returns></returns>
+	public Decision Publish<T>(IEnumerable<Claim> claims, T resource);
+
+	/// <summary>
+	/// Authorize reading or viewing a resource
+	/// </summary>
+	/// <param name="claims"></param>
+	/// <param name="resource"></param>
+	/// <typeparam name="T"></typeparam>
+	/// <returns></returns>
+	public Decision View<T>(IEnumerable<Claim> claims, T resource);
 
 	// TODO: collections/tags/whatever we call them
 	// TODO: account stuff


### PR DESCRIPTION
Mainly, removed the profileId arg. We're not guaranteed to have an active profile, so we should instead just use the claims.