### PR TITLE
add admin account info to Quick Start

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,10 @@ dotnet watch run --project Source/Letterbook.--launch-profile dev
 5. Open the UI http://localhost:5127  
 There is also a Swagger UI http://localhost:5127/swagger/index.html
 
+The setup process creates an `admin` account with:
+- email: `admin@letterbook.example`
+- password: `Password1!`
+
 ## Navigating the Codebase
 
 ### Start with `Letterbook.Core`


### PR DESCRIPTION
This PR adds the default admin account credentials to the Quick Start section of the  `CONTRIBUTING` guide, for easier discovery.
