### PR TITLE
chore: profile url routes

### DIFF
--- a/Source/Letterbook.Api/Controllers/ProfilesController.cs
+++ b/Source/Letterbook.Api/Controllers/ProfilesController.cs
@@ -5,6 +5,7 @@ using Letterbook.Core;
 using Letterbook.Core.Exceptions;
 using Letterbook.Core.Models.Dto;
 using Letterbook.Core.Models.Mappers;
+using MassTransit.Testing;
 using Medo;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -53,8 +54,8 @@ public class ProfilesController : ControllerBase
 	[SwaggerOperation("Get", "Lookup a profile by ID")]
 	public async Task<IActionResult> Get([FromQuery]string handle)
 	{
-		var result = await _profiles.As(User.Claims).FindProfiles(handle);
-		return result.Any()
+		var result = _profiles.As(User.Claims).FindProfiles(handle);
+		return await result.Any()
 			? Ok(_mapper.Map<IEnumerable<FullProfileDto>>(result))
 			: NotFound();
 	}

--- a/Source/Letterbook.Api/WebfingerProvider.cs
+++ b/Source/Letterbook.Api/WebfingerProvider.cs
@@ -40,8 +40,8 @@ public class WebfingerProvider : IResourceDescriptorProvider
 		var handle = match.Value.Split('@', 2,
 			StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
 		if (handle == null) return default;
-		var profiles = await _profiles.As(Enumerable.Empty<Claim>()).FindProfiles(handle);
-		if (profiles.FirstOrDefault() is { } subject)
+		var profile = await _profiles.As([]).FindProfiles(handle, _options.DomainName).FirstOrDefaultAsync(cancellationToken: cancellationToken);
+		if (profile != null)
 		{
 			var descriptor = JsonResourceDescriptor.Empty with
 			{
@@ -50,7 +50,7 @@ public class WebfingerProvider : IResourceDescriptorProvider
 					DarkLink.Web.WebFinger.Shared.Link.Create("self") with
 					{
 						Type = Core.Constants.ActivityPubAccept,
-						Href = subject.FediId,
+						Href = profile.FediId,
 					}),
 			};
 

--- a/Source/Letterbook.Core/Extensions/UriExtensions.cs
+++ b/Source/Letterbook.Core/Extensions/UriExtensions.cs
@@ -4,5 +4,5 @@ public static class UriExtensions
 {
 	public static string GetAuthority(this Uri uri) => uri.IsDefaultPort
 		? string.Join('.', uri.Host.Split('.').Reverse())
-		: string.Join('.', uri.Host.Split('.').Reverse()) + uri.Port;
+		: string.Join('.', uri.Host.Split('.').Reverse()) + $":{uri.Port}";
 }

--- a/Source/Letterbook.Core/IProfileService.cs
+++ b/Source/Letterbook.Core/IProfileService.cs
@@ -42,7 +42,8 @@ public interface IAuthzProfileService
 
 	/// <see cref="LookupProfile(Medo.Uuid7,System.Nullable{Medo.Uuid7})"/>
 	Task<Profile?> LookupProfile(Uri fediId, ProfileId? relatedProfile = null);
-	Task<IEnumerable<Profile>> FindProfiles(string handle);
+	IAsyncEnumerable<Profile> FindProfiles(string handle, string host);
+	IAsyncEnumerable<Profile> FindProfiles(string handle);
 
 	/// <see cref="Follow(Medo.Uuid7,Medo.Uuid7)"/>
 	Task<FollowerRelation> Follow(ProfileId selfId, Uri targetId);

--- a/Source/Letterbook.Core/Models/Profile.cs
+++ b/Source/Letterbook.Core/Models/Profile.cs
@@ -8,7 +8,22 @@ using Microsoft.AspNetCore.Routing;
 
 namespace Letterbook.Core.Models;
 
-public partial record struct ProfileId(Uuid7 Id) : ITypedId<Uuid7>, IParameterPolicy;
+public partial record struct ProfileId(Uuid7 Id) : ITypedId<Uuid7>, IParameterPolicy
+{
+	public static bool TryParse(string id, out ProfileId o)
+	{
+		try
+		{
+			o = FromString(id);
+			return true;
+		}
+		catch (Exception)
+		{
+			o = default;
+			return false;
+		}
+	}
+}
 
 /// <summary>
 /// A Profile is the externally visible representation of an account on the network. In ActivityPub terms, it should map

--- a/Source/Letterbook.Core/Models/Profile.cs
+++ b/Source/Letterbook.Core/Models/Profile.cs
@@ -4,10 +4,11 @@ using Letterbook.Core.Extensions;
 using Letterbook.Core.Values;
 using Letterbook.Generators;
 using Medo;
+using Microsoft.AspNetCore.Routing;
 
 namespace Letterbook.Core.Models;
 
-public partial record struct ProfileId(Uuid7 Id) : ITypedId<Uuid7>;
+public partial record struct ProfileId(Uuid7 Id) : ITypedId<Uuid7>, IParameterPolicy;
 
 /// <summary>
 /// A Profile is the externally visible representation of an account on the network. In ActivityPub terms, it should map

--- a/Source/Letterbook.Core/ProfileService.cs
+++ b/Source/Letterbook.Core/ProfileService.cs
@@ -214,17 +214,14 @@ public class ProfileService : IProfileService, IAuthzProfileService
 		return result;
 	}
 
-	public async Task<IEnumerable<Profile>> FindProfiles(string handle)
+	public IAsyncEnumerable<Profile> FindProfiles(string handle, string host)
 	{
-		var results = _data.AllProfiles().Where(p => p.Handle == handle).AsAsyncEnumerable();//FindProfilesByHandle(handle);
+		return _data.AllProfiles().Where(p => p.Handle == handle && p.Authority == host).AsAsyncEnumerable();
+	}
 
-		var profiles = new List<Profile>();
-		await foreach (var profile in results)
-		{
-			profiles.Add(profile);
-		}
-
-		return profiles;
+	public IAsyncEnumerable<Profile> FindProfiles(string handle)
+	{
+		return _data.AllProfiles().Where(p => p.Handle == handle).AsAsyncEnumerable();
 	}
 
 	private async Task<FollowerRelation> Follow(Profile self, Profile target, bool subscribeOnly)

--- a/Source/Letterbook.Web/DependencyInjection.cs
+++ b/Source/Letterbook.Web/DependencyInjection.cs
@@ -1,6 +1,8 @@
+using Letterbook.Web.Routes;
 using Medo;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Letterbook.Web;
@@ -27,8 +29,14 @@ public static class DependencyInjection
 
 	public static void AddWebRoutes(this RazorPagesOptions options)
 	{
-		// options.Conventions.AddPageRoute("/Profile", "/@{handle}");
-		// options.Conventions.AddPageRoute("/Profile", "/@{handle}@{host}");
-		// options.Conventions.AddPageRoute("/Profile", "/profile/{id}");
+		options.Conventions.Add(new PageRouteTransformerConvention(new ProfileHandleParameterTransformer()));
+		options.Conventions.Add(new PageRouteTransformerConvention(new ProfileIdParameterTransformer()));
+		options.Conventions.AddPageRoute("/Profile", "/{id:handle}");
+	}
+
+	public static void ConfigureWebRoutes(this RouteOptions options)
+	{
+		options.ConstraintMap.Add("handle", typeof(ProfileHandleParameterTransformer));
+		options.LowercaseUrls = true;
 	}
 }

--- a/Source/Letterbook.Web/DependencyInjection.cs
+++ b/Source/Letterbook.Web/DependencyInjection.cs
@@ -1,5 +1,7 @@
+using Medo;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Letterbook.Web;
 
@@ -21,5 +23,12 @@ public static class DependencyInjection
 			options.SlidingExpiration = true;
 			options.ExpireTimeSpan = TimeSpan.FromDays(90);
 		});
+	}
+
+	public static void AddWebRoutes(this RazorPagesOptions options)
+	{
+		// options.Conventions.AddPageRoute("/Profile", "/@{handle}");
+		// options.Conventions.AddPageRoute("/Profile", "/@{handle}@{host}");
+		// options.Conventions.AddPageRoute("/Profile", "/profile/{id}");
 	}
 }

--- a/Source/Letterbook.Web/Letterbook.Web.csproj
+++ b/Source/Letterbook.Web/Letterbook.Web.csproj
@@ -72,6 +72,8 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <CopyToPublishDirectory>Never</CopyToPublishDirectory>
         </Content>
+        <Content Remove="Pages\ProfileWithhost.cshtml" />
+        <Content Remove="Pages\Shared\Components\ProfileViewComponent.cshtml" />
     </ItemGroup>
 
     <ItemGroup>
@@ -88,5 +90,14 @@
       <_ContentIncludedByDefault Remove="wwwroot\lib\remixicon\reply-line.svg" />
       <_ContentIncludedByDefault Remove="wwwroot\lib\remixicon\search-line.svg" />
       <_ContentIncludedByDefault Remove="wwwroot\lib\remixicon\settings-3-line.svg" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Compile Remove="Pages\ProfileWithhost.cshtml.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Folder Include="Pages\Shared\Components\Profile\" />
+      <Folder Include="ViewComponents\" />
     </ItemGroup>
 </Project>

--- a/Source/Letterbook.Web/Pages/Profile.cshtml
+++ b/Source/Letterbook.Web/Pages/Profile.cshtml
@@ -1,38 +1,38 @@
-﻿@page "/@{handle}"
+﻿@page "{id}"
 @model Letterbook.Web.Pages.Profile
 
 @{
-    ViewData["Title"] = $"{Model.DisplayName} ({Model.Handle})";
+    ViewData["Title"] = $"{Model.DisplayName} ({Model.FullHandle})";
 }
 
 <div>
     <h1>
         <span>@Model.DisplayName</span>
-        <span>@Model.Handle</span>
+        <span>@Model.FullHandle</span>
     </h1>
     
-    @if (User.Identity?.IsAuthenticated == true && Model.SelfId == Model.Id)
+    @if (User.Identity?.IsAuthenticated == true && Model.SelfId == Model.GetId)
     {
         <a asp-page="ProfileEdit" asp-route-handle="@Model.BareHandle">Edit</a>
     }
-    @if (User.Identity?.IsAuthenticated == true && Model.SelfId != Model.Id)
+    @if (User.Identity?.IsAuthenticated == true && Model.SelfId != Model.GetId)
     {
         if (Model.YouFollow)
         {
             
-            <form asp-page-handler="Unfollow" asp-route-followId="@Model.Id" method="post">
+            <form asp-page-handler="Unfollow" asp-route-followId="@Model.GetId" method="post">
                 <button>Unfollow</button>
             </form>
         }
         else
         {
-            <form asp-page-handler="FollowRequest" asp-route-followId="@Model.Id" method="post">
+            <form asp-page-handler="FollowRequest" asp-route-followId="@Model.GetId" method="post">
                 <button>Follow</button>
             </form>
         }
         if(Model.FollowsYou)
         {
-            <form asp-page-handler="RemoveFollower" asp-route-followerId="@Model.Id" method="post">
+            <form asp-page-handler="RemoveFollower" asp-route-followerId="@Model.GetId" method="post">
                 <span>Follows you</span>
                 <button>Remove follower</button>
             </form>
@@ -64,6 +64,6 @@
         
     </div>
     
-    <p>Profile Id: <code>@Model.Id</code></p>
+    <p>Profile Id: <code>@Model.GetId</code></p>
     
 </div>

--- a/Source/Letterbook.Web/Pages/Profile.cshtml.cs
+++ b/Source/Letterbook.Web/Pages/Profile.cshtml.cs
@@ -66,12 +66,12 @@ public class Profile : PageModel
 	{
 		_profiles = _profileSvc.As(User.Claims);
 
-		var found = await _profiles.FindProfiles(handle);
-		if (found.FirstOrDefault() is not { } profile)
+		var found = await _profiles.FindProfiles(handle).FirstOrDefaultAsync();
+		if (found is null)
 			return NotFound();
 
-		_profile = profile;
-		if (SelfId is { } id && await _profiles.LookupProfile((Models.ProfileId)Uuid7.FromId25String(id), (Models.ProfileId?)profile.GetId()) is { } self)
+		_profile = found;
+		if (SelfId is { } id && await _profiles.LookupProfile((Models.ProfileId)Uuid7.FromId25String(id), (Models.ProfileId?)found.GetId()) is { } self)
 		{
 			_self = self;
 		}

--- a/Source/Letterbook.Web/Pages/Profile.cshtml.cs
+++ b/Source/Letterbook.Web/Pages/Profile.cshtml.cs
@@ -1,6 +1,5 @@
-﻿using AutoMapper;
-using Letterbook.Core;
-using Letterbook.Core.Models.Mappers;
+﻿using Letterbook.Core;
+using Letterbook.Core.Extensions;
 using Medo;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -16,13 +15,14 @@ public class Profile : PageModel
 {
 	private readonly IProfileService _profileSvc;
 	private readonly ILogger<Profile> _logger;
+	private readonly CoreOptions _opts;
 	private IAuthzProfileService _profiles;
 	private Models.Profile _profile;
 	private Models.Profile? _self;
 
 	/// The full conventional fediverse @user@domain username.
 	/// Ostensibly globally unique
-	public string Handle => $"@{BareHandle}@{_profile.Authority}";
+	public string FullHandle => $"@{BareHandle}@{_profile.Authority}";
 
 	/// Just the username, with no @'s
 	public string BareHandle => _profile.Handle;
@@ -43,7 +43,7 @@ public class Profile : PageModel
 	public Task<int> FollowingCount => _profiles.FollowingCount(_profile);
 
 	/// The internal unique ID for this profile (used a lot in our APIs)
-	public string Id => _profile.GetId25();
+	public string GetId => _profile.GetId25();
 
 	public string? SelfId => User.Claims.FirstOrDefault(c => c.Type == "activeProfile")?.Value;
 
@@ -54,29 +54,56 @@ public class Profile : PageModel
 	public bool YouFollow => _self?.FollowingCollection.Any() ?? false;
 
 
-	public Profile(IProfileService profiles, ILogger<Profile> logger)
+	public Profile(IProfileService profiles, ILogger<Profile> logger, IOptions<CoreOptions> opts)
 	{
 		_profile = default!;
 		_profiles = default!;
 		_profileSvc = profiles;
 		_logger = logger;
+		_opts = opts.Value;
 	}
 
-	public async Task<IActionResult> OnGet(string handle)
+	public async Task<IActionResult> OnGet(string id)
 	{
 		_profiles = _profileSvc.As(User.Claims);
 
-		var found = await _profiles.FindProfiles(handle).FirstOrDefaultAsync();
-		if (found is null)
-			return NotFound();
+		if (id.StartsWith('@')) return await GetByHandle(id);
+		return await GetById(id);
+	}
 
-		_profile = found;
-		if (SelfId is { } id && await _profiles.LookupProfile((Models.ProfileId)Uuid7.FromId25String(id), (Models.ProfileId?)found.GetId()) is { } self)
+	private async Task<IActionResult> GetById(string id)
+	{
+		if (!Models.ProfileId.TryParse(id, out var profileId)) return BadRequest();
+
+		if (await _profiles.LookupProfile(profileId) is not { } profile)
+			return NotFound();
+		_profile = profile;
+
+		await GetSelf();
+
+		return Page();
+	}
+
+	public async Task<IActionResult> GetByHandle(string id)
+	{
+		var parts = id.Split("@", 2, StringSplitOptions.RemoveEmptyEntries);
+		var handle = parts[0];
+		var host = parts.Length == 2 ? parts[1] : _opts.BaseUri().GetAuthority();
+		if (await _profiles.FindProfiles(handle, host).FirstOrDefaultAsync() is not { } profile)
+			return NotFound();
+		_profile = profile;
+
+		await GetSelf();
+
+		return Page();
+	}
+
+	private async Task GetSelf()
+	{
+		if (SelfId is { } selfId && await _profiles.LookupProfile(Models.ProfileId.FromString(selfId), _profile.Id) is { } self)
 		{
 			_self = self;
 		}
-
-		return Page();
 	}
 
 	public async Task<IActionResult> OnPostFollowRequest(string handle, Uuid7 followId)
@@ -111,7 +138,7 @@ public class Profile : PageModel
 			return Challenge();
 
 		_profiles = _profileSvc.As(User.Claims);
-		var result = await _profiles.RemoveFollower(Uuid7.FromId25String(selfId), followerId);
+		await _profiles.RemoveFollower(Uuid7.FromId25String(selfId), followerId);
 
 		return RedirectToPage(GetType().Name, new { handle });
 	}

--- a/Source/Letterbook.Web/Pages/ProfileEdit.cshtml
+++ b/Source/Letterbook.Web/Pages/ProfileEdit.cshtml
@@ -1,4 +1,4 @@
-@page "/@{handle}/edit"
+@page "/{id}/edit"
 @model Letterbook.Web.Pages.ProfileEdit
 
 @{

--- a/Source/Letterbook.Web/Pages/ProfileEdit.cshtml.cs
+++ b/Source/Letterbook.Web/Pages/ProfileEdit.cshtml.cs
@@ -36,25 +36,25 @@ public class ProfileEdit : PageModel
 
     public async Task<IActionResult> OnGet(string handle)
     {
-        var found = await _profiles.As(User.Claims).FindProfiles(handle);
-		if (found.FirstOrDefault() is not { } profile)
+        var found = await _profiles.As(User.Claims).FindProfiles(handle).FirstOrDefaultAsync();
+		if (found is null)
 			return NotFound();
 
 		Handle = handle;
-		DisplayName = profile.DisplayName;
-		Description = profile.Description;
+		DisplayName = found.DisplayName;
+		Description = found.Description;
         return Page();
     }
 
 	public async Task<IActionResult> OnPostAsync(string handle)
 	{
-		var found = await _profiles.As(User.Claims).FindProfiles(handle);
-		if (found.FirstOrDefault() is not { } profile)
+		var found = await _profiles.As(User.Claims).FindProfiles(handle).FirstOrDefaultAsync();
+		if (found is null)
 			return NotFound();
 
 		if (ModelState.IsValid) {
-			await _profiles.As(User.Claims).UpdateDisplayName(profile.Id, DisplayName);
-			await _profiles.As(User.Claims).UpdateDescription(profile.Id, Description);
+			await _profiles.As(User.Claims).UpdateDisplayName(found.Id, DisplayName);
+			await _profiles.As(User.Claims).UpdateDescription(found.Id, Description);
 			return RedirectToPage("Profile", new { handle = handle });
 		}
 		return Page();

--- a/Source/Letterbook.Web/Pages/ProfileEdit.cshtml.cs
+++ b/Source/Letterbook.Web/Pages/ProfileEdit.cshtml.cs
@@ -34,28 +34,28 @@ public class ProfileEdit : PageModel
 	[StringLength(1000)]
 	public string Description { get; set; }
 
-    public async Task<IActionResult> OnGet(string handle)
+    public async Task<IActionResult> OnGet(Models.ProfileId id)
     {
-        var found = await _profiles.As(User.Claims).FindProfiles(handle).FirstOrDefaultAsync();
-		if (found is null)
+	    var profile = await _profiles.As(User.Claims).LookupProfile(id);
+		if (profile == null)
 			return NotFound();
 
-		Handle = handle;
-		DisplayName = found.DisplayName;
-		Description = found.Description;
+		Handle = profile.Handle;
+		DisplayName = profile.DisplayName;
+		Description = profile.Description;
         return Page();
     }
 
-	public async Task<IActionResult> OnPostAsync(string handle)
+	public async Task<IActionResult> OnPostAsync(Models.ProfileId id)
 	{
-		var found = await _profiles.As(User.Claims).FindProfiles(handle).FirstOrDefaultAsync();
-		if (found is null)
+		var profile = await _profiles.As(User.Claims).LookupProfile(id);
+		if (profile == null)
 			return NotFound();
 
 		if (ModelState.IsValid) {
-			await _profiles.As(User.Claims).UpdateDisplayName(found.Id, DisplayName);
-			await _profiles.As(User.Claims).UpdateDescription(found.Id, Description);
-			return RedirectToPage("Profile", new { handle = handle });
+			await _profiles.As(User.Claims).UpdateDisplayName(profile.Id, DisplayName);
+			await _profiles.As(User.Claims).UpdateDescription(profile.Id, Description);
+			return RedirectToPage("Profile", new { handle = profile.Handle });
 		}
 		return Page();
 	}

--- a/Source/Letterbook.Web/Pages/Shared/_Layout.cshtml
+++ b/Source/Letterbook.Web/Pages/Shared/_Layout.cshtml
@@ -25,7 +25,7 @@
                 <a asp-area="" asp-page="/Settings">Settings</a>
                 <div class="spacer min-md"></div>
                 <footer>
-                    <a asp-page="Profile" asp-route-handle="admin">Admin profile</a>
+                    <a asp-page="Profile" asp-route-id="admin">Admin profile</a>
                     <a asp-area="" asp-page="/About">About</a>
                     @if (User.Identity?.IsAuthenticated == true)
                     {

--- a/Source/Letterbook.Web/Pages/Shared/_ProfileSelector.cshtml
+++ b/Source/Letterbook.Web/Pages/Shared/_ProfileSelector.cshtml
@@ -11,7 +11,7 @@
         return;
 }
 <span >
-    <a asp-page="Profile" asp-route-handle="@profile.Handle">
+    <a asp-page="Profile" asp-route-id="@profile.Handle">
         <img src="/img/user-square.png" class="inline"/>
         <span>Profile</span>
     </a>

--- a/Source/Letterbook.Web/Program.cs
+++ b/Source/Letterbook.Web/Program.cs
@@ -6,6 +6,7 @@ using Letterbook.AspNet;
 using Letterbook.Core;
 using Letterbook.Core.Exceptions;
 using Letterbook.Core.Extensions;
+using Letterbook.Web.Routes;
 using Letterbook.Workers;
 using MassTransit;
 using Microsoft.AspNetCore.Authentication;
@@ -74,10 +75,7 @@ public class Program
 			{
 				options.AddWebRoutes();
 			});
-		builder.Services.Configure<RouteOptions>(options =>
-		{
-			options.LowercaseUrls = true;
-		});
+		builder.Services.Configure<RouteOptions>(opts => opts.ConfigureWebRoutes());
 		builder.Services.AddAuthorization(options =>
 		{
 			options.AddWebAuthzPolicy();

--- a/Source/Letterbook.Web/Program.cs
+++ b/Source/Letterbook.Web/Program.cs
@@ -71,10 +71,7 @@ public class Program
 			// We can work around some of the issues by overriding pages under Areas/IdentityPages/Account
 			.AddDefaultUI();
 		builder.Services.AddRazorPages()
-			.AddRazorPagesOptions(options =>
-			{
-				options.AddWebRoutes();
-			});
+			.AddRazorPagesOptions(options => options.AddWebRoutes());
 		builder.Services.Configure<RouteOptions>(opts => opts.ConfigureWebRoutes());
 		builder.Services.AddAuthorization(options =>
 		{

--- a/Source/Letterbook.Web/Program.cs
+++ b/Source/Letterbook.Web/Program.cs
@@ -69,7 +69,15 @@ public class Program
 			//
 			// We can work around some of the issues by overriding pages under Areas/IdentityPages/Account
 			.AddDefaultUI();
-		builder.Services.AddRazorPages();
+		builder.Services.AddRazorPages()
+			.AddRazorPagesOptions(options =>
+			{
+				options.AddWebRoutes();
+			});
+		builder.Services.Configure<RouteOptions>(options =>
+		{
+			options.LowercaseUrls = true;
+		});
 		builder.Services.AddAuthorization(options =>
 		{
 			options.AddWebAuthzPolicy();

--- a/Source/Letterbook.Web/Routes/ProfileHandleParameterTransformer.cs
+++ b/Source/Letterbook.Web/Routes/ProfileHandleParameterTransformer.cs
@@ -1,0 +1,9 @@
+namespace Letterbook.Web.Routes;
+
+public class ProfileHandleParameterTransformer : IOutboundParameterTransformer
+{
+	public string? TransformOutbound(object? value)
+	{
+		return value == null ? null : $"@{value}";
+	}
+}

--- a/Source/Letterbook.Web/Routes/ProfileIdParameterTransformer.cs
+++ b/Source/Letterbook.Web/Routes/ProfileIdParameterTransformer.cs
@@ -1,0 +1,14 @@
+namespace Letterbook.Web.Routes;
+
+public class ProfileIdParameterTransformer : IOutboundParameterTransformer
+{
+	public string? TransformOutbound(object? value)
+	{
+		return value switch
+		{
+			Models.ProfileId p => p.ToString(),
+			string s => s,
+			_ => null
+		};
+	}
+}

--- a/Source/Letterbook/Program.cs
+++ b/Source/Letterbook/Program.cs
@@ -65,7 +65,9 @@ public class Program
 			.AddDefaultTokenProviders()
 			.AddDefaultUI();
 		builder.Services.AddRazorPages()
-			.AddApplicationPart(Assembly.GetAssembly(typeof(Web.Program))!);
+			.AddApplicationPart(Assembly.GetAssembly(typeof(Web.Program))!)
+			.AddRazorPagesOptions(options => options.AddWebRoutes());
+		builder.Services.Configure<RouteOptions>(opts => opts.ConfigureWebRoutes());
 		builder.Services.AddAuthorization(options =>
 		{
 			options.AddWebAuthzPolicy();

--- a/Tests/Letterbook.Api.Tests/WebfingerTests.cs
+++ b/Tests/Letterbook.Api.Tests/WebfingerTests.cs
@@ -29,8 +29,8 @@ public class WebfingerTests : WithMocks
 	[Fact(DisplayName = "Should return the descriptor")]
 	public async Task GetsDescriptor()
 	{
-		ProfileServiceAuthMock.Setup(m => m.FindProfiles(_profile.Handle))
-			.ReturnsAsync(new List<Models.Profile> { _profile });
+		ProfileServiceAuthMock.Setup(m => m.FindProfiles(_profile.Handle, It.IsAny<string>()))
+			.Returns(new List<Models.Profile> { _profile }.ToAsyncEnumerable());
 
 		var actual = await _provider.GetResourceDescriptorAsync(new Uri($"acct:{_profile.Handle}@letterbook.example"),
 			Array.Empty<string>(), Mock.Of<HttpRequest>(), CancellationToken.None);
@@ -43,8 +43,8 @@ public class WebfingerTests : WithMocks
 	[Fact(DisplayName = "Should not return a descriptor when no profiles are found")]
 	public async Task GetsNoDescriptor()
 	{
-		ProfileServiceAuthMock.Setup(m => m.FindProfiles(_profile.Handle))
-			.ReturnsAsync(Array.Empty<Models.Profile>());
+		ProfileServiceAuthMock.Setup(m => m.FindProfiles(_profile.Handle, It.IsAny<string>()))
+			.Returns(Array.Empty<Models.Profile>().ToAsyncEnumerable());
 
 		var actual = await _provider.GetResourceDescriptorAsync(new Uri($"acct:{_profile.Handle}@letterbook.example"),
 			Array.Empty<string>(), Mock.Of<HttpRequest>(), CancellationToken.None);
@@ -59,7 +59,7 @@ public class WebfingerTests : WithMocks
 		req.SetupGet<IHeaderDictionary>(m => m.Headers).Returns(new HeaderDictionary());
 
 		ProfileServiceAuthMock.Setup(m => m.FindProfiles(_profile.Handle))
-			.ReturnsAsync(Array.Empty<Models.Profile>());
+			.Returns(Array.Empty<Models.Profile>().ToAsyncEnumerable());
 
 		var actual = await _provider.GetResourceDescriptorAsync(new Uri($"acct:{_profile.Handle}"),
 			Array.Empty<string>(), req.Object, CancellationToken.None);

--- a/Tests/Letterbook.Web.Mocks/Program.cs
+++ b/Tests/Letterbook.Web.Mocks/Program.cs
@@ -68,7 +68,16 @@ public class Program
 			// We can work around some of the issues by overriding pages under Areas/IdentityPages/Account
 			.AddDefaultUI();
 		builder.Services.AddRazorPages()
-			.AddApplicationPart(Assembly.GetAssembly(typeof(Web.Program))!);
+			.AddApplicationPart(Assembly.GetAssembly(typeof(Web.Program))!)
+			.AddRazorPagesOptions(options =>
+			{
+				options.AddWebRoutes();
+			});
+		builder.Services.Configure<RouteOptions>(options =>
+		{
+			// options.ConstraintMap.Add(nameof(Models.ProfileId), typeof(Models.ProfileId));
+			options.LowercaseUrls = true;
+		});
 		builder.Services.AddAuthorization(options =>
 		{
 			options.AddWebAuthzPolicy();
@@ -80,27 +89,12 @@ public class Program
 
 		var app = builder.Build();
 
-		// Configure the HTTP request pipeline.
-		if (!app.Environment.IsDevelopment())
-		{
-			// Not sure if this works, with mixed Razor/WebApi
-			app.UseExceptionHandler("/Error");
-		}
-
-		if (!app.Environment.IsProduction())
-		{
-			app.Use((context, next) =>
-			{
-				context.Request.EnableBuffering();
-				return next();
-			});
-		}
-
+		app.UseDeveloperExceptionPage();
 		app.UseStaticFiles(new StaticFileOptions
 		{
 			FileProvider = new ManifestEmbeddedFileProvider(Assembly.GetAssembly(typeof(Web.Program))!, "wwwroot"),
 		});
-		app.UseStatusCodePagesWithReExecute("/error/{0}");
+		// app.UseStatusCodePagesWithReExecute("/error/{0}");
 
 		app.UseHealthChecks("/healthz");
 		app.MapPrometheusScrapingEndpoint();

--- a/Tests/Letterbook.Web.Mocks/Program.cs
+++ b/Tests/Letterbook.Web.Mocks/Program.cs
@@ -69,10 +69,7 @@ public class Program
 			.AddDefaultUI();
 		builder.Services.AddRazorPages()
 			.AddApplicationPart(Assembly.GetAssembly(typeof(Web.Program))!)
-			.AddRazorPagesOptions(options =>
-			{
-				options.AddWebRoutes();
-			});
+			.AddRazorPagesOptions(options => options.AddWebRoutes());
 		builder.Services.Configure<RouteOptions>(opts => opts.ConfigureWebRoutes());
 		builder.Services.AddAuthorization(options =>
 		{

--- a/Tests/Letterbook.Web.Mocks/Program.cs
+++ b/Tests/Letterbook.Web.Mocks/Program.cs
@@ -73,11 +73,7 @@ public class Program
 			{
 				options.AddWebRoutes();
 			});
-		builder.Services.Configure<RouteOptions>(options =>
-		{
-			// options.ConstraintMap.Add(nameof(Models.ProfileId), typeof(Models.ProfileId));
-			options.LowercaseUrls = true;
-		});
+		builder.Services.Configure<RouteOptions>(opts => opts.ConfigureWebRoutes());
 		builder.Services.AddAuthorization(options =>
 		{
 			options.AddWebAuthzPolicy();
@@ -89,12 +85,12 @@ public class Program
 
 		var app = builder.Build();
 
+		// app.UseStatusCodePagesWithReExecute("/error/{0}");
 		app.UseDeveloperExceptionPage();
 		app.UseStaticFiles(new StaticFileOptions
 		{
 			FileProvider = new ManifestEmbeddedFileProvider(Assembly.GetAssembly(typeof(Web.Program))!, "wwwroot"),
 		});
-		// app.UseStatusCodePagesWithReExecute("/error/{0}");
 
 		app.UseHealthChecks("/healthz");
 		app.MapPrometheusScrapingEndpoint();

--- a/Tests/Letterbook.Web.Mocks/appsettings.Development.json
+++ b/Tests/Letterbook.Web.Mocks/appsettings.Development.json
@@ -12,10 +12,53 @@
     }
   },
   "DetailedErrors": true,
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Console",
+      "Serilog.Expressions",
+      "Serilog.Sinks.Grafana.Loki"
+    ],
+    "MinimumLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.AspNetCore.Hosting": "Information",
+        "System": "Warning",
+        "Letterbook": "Debug"
+      }
+    },
+    "Enrich": [
+      "FromLogContext"
+    ],
+    "WriteTo": [
+      {
+        "Name": "Logger",
+        "Args": {
+          "configureLogger": {
+            "Filter": [
+              {
+                "Name": "ByExcluding",
+                "Args": { "expression": "startsWith(RequestPath, '/metrics')" }
+              },
+              {
+                "Name": "ByExcluding",
+                "Args": { "expression": "startsWith(RequestPath, '/swagger')" }
+              },
+              {
+                "Name": "ByExcluding",
+                "Args": { "expression": "startsWith(RequestPath, '/healthz') AND StatusCode=200" }
+              },
+              {
+                "Name": "ByExcluding",
+                "Args": { "expression": "startsWith(RequestPath, '/favicon')" }
+              }
+            ],
+            "WriteTo": {
+              "Name": "Console"
+            }
+          }
+        }
+      }
+    ]
   }
 }

--- a/Tests/Letterbook.Web.Tests/ProfileControllerTests.cs
+++ b/Tests/Letterbook.Web.Tests/ProfileControllerTests.cs
@@ -1,6 +1,4 @@
 using System.Security.Claims;
-using Letterbook.Core.Models.Mappers;
-using Letterbook.Core.Tests;
 using Letterbook.Core.Tests.Fakes;
 using Letterbook.Core.Values;
 using Letterbook.Web.Pages;
@@ -31,7 +29,7 @@ public class ProfileControllerTests : WithMockContext
 			PageContext = PageContext,
 		};
 
-		ProfileServiceAuthMock.Setup(m => m.FindProfiles(It.IsAny<string>())).ReturnsAsync([_profile]);
+		ProfileServiceAuthMock.Setup(m => m.FindProfiles(It.IsAny<string>(), It.IsAny<string>())).Returns(new List<Models.Profile>{_profile}.ToAsyncEnumerable());
 	}
 
 	[Fact]

--- a/Tests/Letterbook.Web.Tests/ProfileControllerTests.cs
+++ b/Tests/Letterbook.Web.Tests/ProfileControllerTests.cs
@@ -24,7 +24,7 @@ public class ProfileControllerTests : WithMockContext
 		_principal = new ClaimsPrincipal(new ClaimsIdentity([new Claim("activeProfile", _selfProfile.GetId25())], "Test"));
 
 		_profile = new FakeProfile("letterbook.example").Generate();
-		_page = new Profile(ProfileServiceMock.Object, Mock.Of<ILogger<Profile>>())
+		_page = new Profile(ProfileServiceMock.Object, Mock.Of<ILogger<Profile>>(), CoreOptionsMock)
 		{
 			PageContext = PageContext,
 		};
@@ -41,11 +41,11 @@ public class ProfileControllerTests : WithMockContext
 	[Fact(DisplayName = "Should load the template data for a profile")]
 	public async Task CanGetPage()
 	{
-		var result = await _page.OnGet(_profile.Handle);
+		var result = await _page.OnGet($"@{_profile.Handle}");
 
 		Assert.IsType<PageResult>(result);
 		Assert.Equal(_profile.Description, _page.Description.ToString());
-		Assert.Equal($"@{_profile.Handle}@{_profile.Authority}", _page.Handle);
+		Assert.Equal($"@{_profile.Handle}@{_profile.Authority}", _page.FullHandle);
 		Assert.Equal(_profile.DisplayName, _page.DisplayName);
 		Assert.Equal(_profile.CustomFields, _page.CustomFields);
 	}
@@ -59,7 +59,7 @@ public class ProfileControllerTests : WithMockContext
 	{
 		ProfileServiceAuthMock.Setup(m => m.FollowingCount(_profile)).ReturnsAsync(x);
 
-		await _page.OnGet(_profile.Handle);
+		await _page.OnGet($"@{_profile.Handle}");
 
 		Assert.Equal(x, await _page.FollowingCount);
 	}
@@ -73,7 +73,7 @@ public class ProfileControllerTests : WithMockContext
 	{
 		ProfileServiceAuthMock.Setup(m => m.FollowerCount(_profile)).ReturnsAsync(x);
 
-		await _page.OnGet(_profile.Handle);
+		await _page.OnGet($"@{_profile.Handle}");
 
 		Assert.Equal(x, await _page.FollowerCount);
 	}
@@ -83,7 +83,7 @@ public class ProfileControllerTests : WithMockContext
 	{
 		MockHttpContext.SetupGet(ctx => ctx.User).Returns(_principal);
 
-		var result = await _page.OnGet(_profile.Handle);
+		var result = await _page.OnGet($"@{_profile.Handle}");
 
 		Assert.Equal(_selfProfile.GetId25(), _page.SelfId);
 	}
@@ -98,7 +98,7 @@ public class ProfileControllerTests : WithMockContext
 		ProfileServiceAuthMock.Setup(m => m.LookupProfile((Models.ProfileId)_selfProfile.GetId(), (Models.ProfileId?)_profile.GetId()))
 			.ReturnsAsync(_selfProfile);
 
-		await _page.OnGet(_profile.Handle);
+		await _page.OnGet($"@{_profile.Handle}");
 
 		Assert.True(_page.FollowsYou);
 		Assert.True(_page.YouFollow);


### PR DESCRIPTION
This is a refactor to the Profile page's route parameter handling. It enables loading profiles either by handle (with or without the host) or by ID. We don't actually search by ID right now, but we're likely to as we build out more UI. This also has the side benefit of making Rider's problem detection happier. Rider used to flag the `@` in the template as an error. It's not, but it was annoying.

## Details
### The razor template
(Source/Letterbook.Web/Pages/Profile.cshtml)
```csharp
@page "{id}"
```
produces this route template `/profile/{id}`. This comes from the default razor pages route convention.

### The additional convention
(Source/Letterbook.Web/DependencyInjection.cs)
```csharp
options.Conventions.AddPageRoute("/Profile", "/{id:handle}");
```
produces this route template `/{handle}` where `handle` must include the initial `@`, and optionally the hostname. (ex. `@picard` or `@picard@enterprise.example`).

### The `:handle` constraint/transformer
(Source/Letterbook.Web/Routes/ProfileHandleParameterTransformer.cs) handles prepending that `@`. So we don't need to do that in anchor templates.

## Related
- prep for #353 
