### PR TITLE
feat: projected and estimated values

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="BouncyCastle.Cryptography" Version="2.5.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="DarkLink.Web.WebFinger.Server" Version="1.0.0" />
+    <PackageVersion Include="EntityFrameworkCore.Projectables" Version="3.0.4" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="HtmlSanitizer" Version="8.1.870" />
     <PackageVersion Include="ILogger.Moq" Version="1.1.10" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,102 +1,102 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
-    <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include="ActivityPub.Types" Version="0.1.0-snapshot.2024-10-13.21-01-46" />
-    <PackageVersion Include="AutoMapper" Version="13.0.1" />
-    <PackageVersion Include="AutoMapper.Collection" Version="10.0.0" />
-    <PackageVersion Include="Bogus" Version="35.6.1" />
-    <PackageVersion Include="BouncyCastle.Cryptography" Version="2.5.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="DarkLink.Web.WebFinger.Server" Version="1.0.0" />
-    <PackageVersion Include="EntityFrameworkCore.Projectables" Version="3.0.4" />
-    <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
-    <PackageVersion Include="HtmlSanitizer" Version="8.1.870" />
-    <PackageVersion Include="ILogger.Moq" Version="1.1.10" />
-    <PackageVersion Include="Letterbook.Uuid7" Version="2.1.1-patch.12" />
-    <PackageVersion Include="Markdig" Version="0.39.1" />
-    <PackageVersion Include="MassTransit" Version="8.3.4" />
-    <PackageVersion Include="MassTransit.Abstractions" Version="8.3.4" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[8.0.11, 9.0.0)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="[8.0.11, 9.0.0)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="[8.0.11, 9.0.0)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="[8.0.11, 9.0.0)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="[8.0.11, 9.0.0)" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.11, 9.0.0)" />
-    <PackageVersion Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageVersion>
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="[8.0.11, 9.0.0)" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="[8.0.11, 9.0.0)" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="[8.0.11, 9.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[8.0.2, 9.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="[8.0.11, 9.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[8.0.1, 9.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="[8.0.11, 9.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="[8.0.11, 9.0.0)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="[8.0.1, 9.0.0)" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="[8.3.0, 9.0.0)" />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="[8.3.0, 9.0.0)" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="Microsoft.Playwright" Version="1.49.0" />
-    <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.49.0" />
-    <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="[8.0.7, 9.0.0)" />
-    <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />
-    <PackageVersion Include="MockQueryable.Moq" Version="7.0.3" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
-    <!--  Neovolve 6.3+ requires an upgrade to various Microsoft.Abstractions 9.x, which we're not taking yet -->
-    <PackageVersion Include="Neovolve.Logging.Xunit" Version="[6.2.0, 6.3.0)" />
-    <PackageVersion Include="Npgsql" Version="[8.0.6, 9.0.0)" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="[8.0.11, 9.0.0)" />
-    <PackageVersion Include="Npgsql.OpenTelemetry" Version="[8.0.6, 9.0.0)" />
-    <PackageVersion Include="NSign.Abstractions" Version="1.1.1" />
-    <PackageVersion Include="NSign.AspNetCore" Version="1.1.1" />
-    <PackageVersion Include="NSign.Client" Version="1.1.1" />
-    <PackageVersion Include="NSign.SignatureProviders" Version="1.1.1" />
-    <PackageVersion Include="Nunit" Version="4.3.1" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.5.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageVersion>
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="6.0.0" />
-    <!--  OpenTelemetry 1.10+ requires an upgrade to Microsoft.Abstractions.Logging 9.x, which we're not taking yet -->
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="[1.9.0, 1.10)" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="[1.9.0, 1.10)" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="[1.9.0-beta.2, 1.10)" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="[1.9.0, 1.10)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="[1.9.0, 1.10)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="[1.9.0, 1.10)" />
-    <PackageVersion Include="RazorLight" Version="2.3.1" />
-    <PackageVersion Include="Request.Body.Peeker" Version="1.3.0" />
-    <PackageVersion Include="Serilog" Version="4.2.0" />
-    <PackageVersion Include="Serilog.AspNetCore" Version="[8.0.3, 9.0.0)" />
-    <PackageVersion Include="Serilog.Enrichers.Span" Version="3.1.0" />
-    <PackageVersion Include="Serilog.Expressions" Version="5.0.0" />
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="[8.0.0, 9.0.0)" />
-    <PackageVersion Include="Serilog.Settings.Configuration" Version="[8.0.4, 9.0.0)" />
-    <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageVersion Include="Serilog.Sinks.Grafana.Loki" Version="[8.3.0, 9.0.0)" />
-    <PackageVersion Include="ServiceStack" Version="8.5.2" />
-    <PackageVersion Include="ServiceStack.Mvc" Version="8.5.2" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="7.2.0" />
-    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="System.Reactive.Async" Version="6.0.0-alpha.18" />
-    <PackageVersion Include="Verify.Xunit" Version="28.12.1" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
-    <PackageVersion Include="YamlDotNet" Version="16.3.0" />
-  </ItemGroup>
+    <PropertyGroup>
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+        <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
+        <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="ActivityPub.Types" Version="0.1.0-snapshot.2024-10-13.21-01-46"/>
+        <PackageVersion Include="AutoMapper" Version="13.0.1"/>
+        <PackageVersion Include="AutoMapper.Collection" Version="10.0.0"/>
+        <PackageVersion Include="Bogus" Version="35.6.1"/>
+        <PackageVersion Include="BouncyCastle.Cryptography" Version="2.5.0"/>
+        <PackageVersion Include="coverlet.collector" Version="6.0.2"/>
+        <PackageVersion Include="DarkLink.Web.WebFinger.Server" Version="1.0.0"/>
+        <PackageVersion Include="EntityFrameworkCore.Projectables" Version="3.0.4"/>
+        <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1"/>
+        <PackageVersion Include="HtmlSanitizer" Version="8.1.870"/>
+        <PackageVersion Include="ILogger.Moq" Version="1.1.10"/>
+        <PackageVersion Include="Letterbook.Uuid7" Version="2.1.1-patch.12"/>
+        <PackageVersion Include="Markdig" Version="0.39.1"/>
+        <PackageVersion Include="MassTransit" Version="8.3.4"/>
+        <PackageVersion Include="MassTransit.Abstractions" Version="8.3.4"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[8.0.11, 9.0.0)"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="[8.0.11, 9.0.0)"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="[8.0.11, 9.0.0)"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="[8.0.11, 9.0.0)"/>
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="[8.0.11, 9.0.0)"/>
+        <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="[8.0.11, 9.0.0)"/>
+        <PackageVersion Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0"/>
+        <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageVersion>
+        <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.8.0"/>
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0"/>
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.8.0"/>
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="1.1.2"/>
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="[8.0.11, 9.0.0)"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="[8.0.11, 9.0.0)"/>
+        <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="[8.0.11, 9.0.0)"/>
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[8.0.2, 9.0.0)"/>
+        <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="[8.0.11, 9.0.0)"/>
+        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[8.0.1, 9.0.0)"/>
+        <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="[8.0.11, 9.0.0)"/>
+        <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="[8.0.11, 9.0.0)"/>
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="[8.0.1, 9.0.0)"/>
+        <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="[8.3.0, 9.0.0)"/>
+        <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="[8.3.0, 9.0.0)"/>
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
+        <PackageVersion Include="Microsoft.Playwright" Version="1.49.0"/>
+        <PackageVersion Include="Microsoft.Playwright.NUnit" Version="1.49.0"/>
+        <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="[8.0.7, 9.0.0)"/>
+        <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71"/>
+        <PackageVersion Include="MockQueryable.Moq" Version="7.0.3"/>
+        <PackageVersion Include="Moq" Version="4.18.4"/>
+        <!--  Neovolve 6.3+ requires an upgrade to various Microsoft.Abstractions 9.x, which we're not taking yet -->
+        <PackageVersion Include="Neovolve.Logging.Xunit" Version="[6.2.0, 6.3.0)"/>
+        <PackageVersion Include="Npgsql" Version="[8.0.6, 9.0.0)"/>
+        <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="[8.0.11, 9.0.0)"/>
+        <PackageVersion Include="Npgsql.OpenTelemetry" Version="[8.0.6, 9.0.0)"/>
+        <PackageVersion Include="NSign.Abstractions" Version="1.1.1"/>
+        <PackageVersion Include="NSign.AspNetCore" Version="1.1.1"/>
+        <PackageVersion Include="NSign.Client" Version="1.1.1"/>
+        <PackageVersion Include="NSign.SignatureProviders" Version="1.1.1"/>
+        <PackageVersion Include="Nunit" Version="4.3.1"/>
+        <PackageVersion Include="NUnit.Analyzers" Version="4.5.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageVersion>
+        <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0"/>
+        <PackageVersion Include="OpenIddict.EntityFrameworkCore" Version="6.0.0"/>
+        <!--  OpenTelemetry 1.10+ requires an upgrade to Microsoft.Abstractions.Logging 9.x, which we're not taking yet -->
+        <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="[1.9.0, 1.10)"/>
+        <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="[1.9.0, 1.10)"/>
+        <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="[1.9.0-beta.2, 1.10)"/>
+        <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="[1.9.0, 1.10)"/>
+        <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="[1.9.0, 1.10)"/>
+        <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="[1.9.0, 1.10)"/>
+        <PackageVersion Include="RazorLight" Version="2.3.1"/>
+        <PackageVersion Include="Request.Body.Peeker" Version="1.3.0"/>
+        <PackageVersion Include="Serilog" Version="4.2.0"/>
+        <PackageVersion Include="Serilog.AspNetCore" Version="[8.0.3, 9.0.0)"/>
+        <PackageVersion Include="Serilog.Enrichers.Span" Version="3.1.0"/>
+        <PackageVersion Include="Serilog.Expressions" Version="5.0.0"/>
+        <PackageVersion Include="Serilog.Extensions.Hosting" Version="[8.0.0, 9.0.0)"/>
+        <PackageVersion Include="Serilog.Settings.Configuration" Version="[8.0.4, 9.0.0)"/>
+        <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0"/>
+        <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0"/>
+        <PackageVersion Include="Serilog.Sinks.Grafana.Loki" Version="[8.3.0, 9.0.0)"/>
+        <PackageVersion Include="ServiceStack" Version="8.5.2"/>
+        <PackageVersion Include="ServiceStack.Mvc" Version="8.5.2"/>
+        <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0"/>
+        <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="7.2.0"/>
+        <PackageVersion Include="System.Linq.Async" Version="6.0.1"/>
+        <PackageVersion Include="System.Reactive.Async" Version="6.0.0-alpha.18"/>
+        <PackageVersion Include="Verify.Xunit" Version="28.12.1"/>
+        <PackageVersion Include="xunit" Version="2.9.3"/>
+        <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0"/>
+        <PackageVersion Include="YamlDotNet" Version="16.3.0"/>
+    </ItemGroup>
 </Project>

--- a/Source/Letterbook.Adapter.ActivityPub/Mappers/AstMapper.cs
+++ b/Source/Letterbook.Adapter.ActivityPub/Mappers/AstMapper.cs
@@ -220,6 +220,7 @@ public static class AstMapper
 			.ForMember(dest => dest.ReportSubject, opt => opt.Ignore())
 			.ForMember(dest => dest.FollowersCollection, opt => opt.Ignore())
 			.ForMember(dest => dest.FollowingCollection, opt => opt.Ignore())
+			.ForMember(dest => dest.Posts, opt => opt.Ignore())
 			.ForMember(dest => dest.FediId, opt => opt.MapFrom(src => src.Id))
 			.ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Summary))
 			.ForMember(dest => dest.DisplayName, opt => opt.MapFrom(src => src.Name))
@@ -232,6 +233,9 @@ public static class AstMapper
 			.ForMember(dest => dest.Updated, opt => opt.MapFrom(src => src.Updated))
 			.ForMember(dest => dest.Followers, opt => opt.MapFrom(src => src.Followers))
 			.ForMember(dest => dest.Following, opt => opt.MapFrom(src => src.Following))
+			.ForMember(dest => dest.FollowersEstimate, opt => opt.Ignore())
+			.ForMember(dest => dest.FollowingEstimate, opt => opt.Ignore())
+			.ForMember(dest => dest.PostsEstimate, opt => opt.Ignore())
 			.ForMember(d => d.Keys, opt => opt.MapFrom(s => s.PublicKeys))
 			// .ForMember(dest => dest.Keys, opt => opt.MapFrom<PublicKeyConverter, List<PublicKey>>(src => src.PublicKey!))
 			.AfterMap((profileActor, profile) =>

--- a/Source/Letterbook.Adapter.Db/DependencyInjection.cs
+++ b/Source/Letterbook.Adapter.Db/DependencyInjection.cs
@@ -12,7 +12,11 @@ public static class DependencyInjection
 	public static IServiceCollection AddDbAdapter(this IServiceCollection services, IConfigurationManager config)
 	{
 		var dataSource = DataSource(config);
-		return services.AddDbContext<RelationalContext>(options => options.UseNpgsql(dataSource))
+		return services.AddDbContext<RelationalContext>(options =>
+			{
+				options.UseNpgsql(dataSource);
+				options.UseProjectables();
+			})
 			.AddScoped<IDataAdapter, DataAdapter>();
 	}
 

--- a/Source/Letterbook.Adapter.Db/EntityConfigs/ConfigurePost.cs
+++ b/Source/Letterbook.Adapter.Db/EntityConfigs/ConfigurePost.cs
@@ -13,7 +13,7 @@ public class ConfigurePost : IEntityTypeConfiguration<Models.Post>
 		builder.HasMany<Models.Content>(post => post.Contents)
 			.WithOne(content => content.Post);
 		builder.HasMany<Models.Profile>(post => post.Creators)
-			.WithMany("CreatedPosts")
+			.WithMany(profile => profile.Posts)
 			.UsingEntity("PostsCreatedByProfile");
 		builder.HasMany<Models.Profile>(post => post.LikesCollection)
 			.WithMany("LikedPosts")

--- a/Source/Letterbook.Adapter.Db/EntityConfigs/ConfigureProfile.cs
+++ b/Source/Letterbook.Adapter.Db/EntityConfigs/ConfigureProfile.cs
@@ -21,5 +21,8 @@ public class ConfigureProfile : IEntityTypeConfiguration<Models.Profile>
 			.WithOne(relation => relation.Follows)
 			.IsRequired();
 		builder.Property(profile => profile.Restrictions).HasColumnType("jsonb");
+		builder.Property(profile => profile.FollowersEstimate).HasDefaultValue(-1);
+		builder.Property(profile => profile.FollowingEstimate).HasDefaultValue(-1);
+		builder.Property(profile => profile.PostsEstimate).HasDefaultValue(-1);
 	}
 }

--- a/Source/Letterbook.Adapter.Db/Migrations/20250415040209_ProfileProjectionsAndEstimates.Designer.cs
+++ b/Source/Letterbook.Adapter.Db/Migrations/20250415040209_ProfileProjectionsAndEstimates.Designer.cs
@@ -5,6 +5,7 @@ using Letterbook.Adapter.Db;
 using Letterbook.Core.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -13,9 +14,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Letterbook.Adapter.Db.Migrations
 {
     [DbContext(typeof(RelationalContext))]
-    partial class RelationalContextModelSnapshot : ModelSnapshot
+    [Migration("20250415040209_ProfileProjectionsAndEstimates")]
+    partial class ProfileProjectionsAndEstimates
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Source/Letterbook.Adapter.Db/Migrations/20250415040209_ProfileProjectionsAndEstimates.cs
+++ b/Source/Letterbook.Adapter.Db/Migrations/20250415040209_ProfileProjectionsAndEstimates.cs
@@ -1,0 +1,121 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Letterbook.Adapter.Db.Migrations
+{
+    /// <inheritdoc />
+    public partial class ProfileProjectionsAndEstimates : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PostsCreatedByProfile_Posts_CreatedPostsId",
+                table: "PostsCreatedByProfile");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_PostsCreatedByProfile",
+                table: "PostsCreatedByProfile");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PostsCreatedByProfile_CreatorsId",
+                table: "PostsCreatedByProfile");
+
+            migrationBuilder.RenameColumn(
+                name: "CreatedPostsId",
+                table: "PostsCreatedByProfile",
+                newName: "PostsId");
+
+            migrationBuilder.AddColumn<int>(
+                name: "FollowersEstimate",
+                table: "Profiles",
+                type: "integer",
+                nullable: false,
+                defaultValue: -1);
+
+            migrationBuilder.AddColumn<int>(
+                name: "FollowingEstimate",
+                table: "Profiles",
+                type: "integer",
+                nullable: false,
+                defaultValue: -1);
+
+            migrationBuilder.AddColumn<int>(
+                name: "PostsEstimate",
+                table: "Profiles",
+                type: "integer",
+                nullable: false,
+                defaultValue: -1);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_PostsCreatedByProfile",
+                table: "PostsCreatedByProfile",
+                columns: new[] { "CreatorsId", "PostsId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PostsCreatedByProfile_PostsId",
+                table: "PostsCreatedByProfile",
+                column: "PostsId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PostsCreatedByProfile_Posts_PostsId",
+                table: "PostsCreatedByProfile",
+                column: "PostsId",
+                principalTable: "Posts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PostsCreatedByProfile_Posts_PostsId",
+                table: "PostsCreatedByProfile");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_PostsCreatedByProfile",
+                table: "PostsCreatedByProfile");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PostsCreatedByProfile_PostsId",
+                table: "PostsCreatedByProfile");
+
+            migrationBuilder.DropColumn(
+                name: "FollowersEstimate",
+                table: "Profiles");
+
+            migrationBuilder.DropColumn(
+                name: "FollowingEstimate",
+                table: "Profiles");
+
+            migrationBuilder.DropColumn(
+                name: "PostsEstimate",
+                table: "Profiles");
+
+            migrationBuilder.RenameColumn(
+                name: "PostsId",
+                table: "PostsCreatedByProfile",
+                newName: "CreatedPostsId");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_PostsCreatedByProfile",
+                table: "PostsCreatedByProfile",
+                columns: new[] { "CreatedPostsId", "CreatorsId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PostsCreatedByProfile_CreatorsId",
+                table: "PostsCreatedByProfile",
+                column: "CreatorsId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PostsCreatedByProfile_Posts_CreatedPostsId",
+                table: "PostsCreatedByProfile",
+                column: "CreatedPostsId",
+                principalTable: "Posts",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/Source/Letterbook.Core/Letterbook.Core.csproj
+++ b/Source/Letterbook.Core/Letterbook.Core.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
       <PackageReference Include="ActivityPub.Types" />
       <PackageReference Include="AutoMapper" />
+      <PackageReference Include="BouncyCastle.Cryptography" />
       <PackageReference Include="EntityFrameworkCore.Projectables" />
       <PackageReference Include="GitHubActionsTestLogger">
         <PrivateAssets>all</PrivateAssets>
@@ -46,11 +47,6 @@
       <ProjectReference Include="..\Letterbook.Generators\Letterbook.Generators\Letterbook.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" SetTargetFramework="TargetFramework=netstandard2.0" />
       <!-- Letterbook.Generators must be built targeting the same framework as this project to allow the use of runtime features such as static abstract members on interfaces -->
       <ProjectReference Include="..\Letterbook.Generators\Letterbook.Generators\Letterbook.Generators.csproj" ReferenceOutputAssembly="true" SetTargetFramework="TargetFramework=$(TargetFramework)" />
-    </ItemGroup>
-    <ItemGroup>
-      <Reference Include="BouncyCastle.Cryptography">
-        <HintPath>..\..\..\..\.nuget\packages\bouncycastle.cryptography\2.5.0\lib\net6.0\BouncyCastle.Cryptography.dll</HintPath>
-      </Reference>
     </ItemGroup>
 
 </Project>

--- a/Source/Letterbook.Core/Letterbook.Core.csproj
+++ b/Source/Letterbook.Core/Letterbook.Core.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
       <PackageReference Include="ActivityPub.Types" />
       <PackageReference Include="AutoMapper" />
+      <PackageReference Include="EntityFrameworkCore.Projectables" />
       <PackageReference Include="GitHubActionsTestLogger">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -45,6 +46,11 @@
       <ProjectReference Include="..\Letterbook.Generators\Letterbook.Generators\Letterbook.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" SetTargetFramework="TargetFramework=netstandard2.0" />
       <!-- Letterbook.Generators must be built targeting the same framework as this project to allow the use of runtime features such as static abstract members on interfaces -->
       <ProjectReference Include="..\Letterbook.Generators\Letterbook.Generators\Letterbook.Generators.csproj" ReferenceOutputAssembly="true" SetTargetFramework="TargetFramework=$(TargetFramework)" />
+    </ItemGroup>
+    <ItemGroup>
+      <Reference Include="BouncyCastle.Cryptography">
+        <HintPath>..\..\..\..\.nuget\packages\bouncycastle.cryptography\2.5.0\lib\net6.0\BouncyCastle.Cryptography.dll</HintPath>
+      </Reference>
     </ItemGroup>
 
 </Project>

--- a/Source/Letterbook.Core/Models/Dto/FullProfileDto.cs
+++ b/Source/Letterbook.Core/Models/Dto/FullProfileDto.cs
@@ -15,4 +15,6 @@ public class FullProfileDto
 	public ActivityActorType? Type { get; set; }
 	public ICollection<AudienceDto>? Audiences { get; set; } = new HashSet<AudienceDto>();
 	public IList<PublicKeyDto>? Keys { get; set; } = new List<PublicKeyDto>();
+	public int Followers { get; set; }
+	public int Following { get; set; }
 }

--- a/Source/Letterbook.Core/Models/Mappers/BaseMappings.cs
+++ b/Source/Letterbook.Core/Models/Mappers/BaseMappings.cs
@@ -76,8 +76,8 @@ public class BaseMappings : AutoMapper.Profile
 		CreateMap<string, Models.Profile>(MemberList.None)
 			.ConstructUsing(s => Models.Profile.CreateEmpty(new ProfileId(ProfileId.FromString(s))));
 
-		CreateMap<Uuid7, ProfileId>();
-		CreateMap<ProfileId, Uuid7>();
+		CreateMap<Uuid7, ProfileId>(MemberList.None).ConstructUsing(id => new(id));
+		CreateMap<ProfileId, Uuid7>(MemberList.None).ConstructUsing(id => id.Id);
 
 
 		CreateMap<DateTimeOffset?, DateTimeOffset?>()

--- a/Source/Letterbook.Core/Models/Mappers/BaseMappings.cs
+++ b/Source/Letterbook.Core/Models/Mappers/BaseMappings.cs
@@ -76,6 +76,8 @@ public class BaseMappings : AutoMapper.Profile
 		CreateMap<string, Models.Profile>(MemberList.None)
 			.ConstructUsing(s => Models.Profile.CreateEmpty(new ProfileId(ProfileId.FromString(s))));
 
+		CreateMap<Uuid7, ProfileId>();
+		CreateMap<ProfileId, Uuid7>();
 
 
 		CreateMap<DateTimeOffset?, DateTimeOffset?>()

--- a/Source/Letterbook.Core/Models/Mappers/BaseMappings.cs
+++ b/Source/Letterbook.Core/Models/Mappers/BaseMappings.cs
@@ -76,8 +76,8 @@ public class BaseMappings : AutoMapper.Profile
 		CreateMap<string, Models.Profile>(MemberList.None)
 			.ConstructUsing(s => Models.Profile.CreateEmpty(new ProfileId(ProfileId.FromString(s))));
 
-		CreateMap<Uuid7, ProfileId>(MemberList.None).ConstructUsing(id => new(id));
-		CreateMap<ProfileId, Uuid7>(MemberList.None).ConstructUsing(id => id.Id);
+		CreateMap<Uuid7, ProfileId>(MemberList.None).ConvertUsing(id => new(id));
+		CreateMap<ProfileId, Uuid7>(MemberList.None).ConvertUsing(id => id.Id);
 
 
 		CreateMap<DateTimeOffset?, DateTimeOffset?>()

--- a/Source/Letterbook.Core/Models/Mappers/PostMappings.cs
+++ b/Source/Letterbook.Core/Models/Mappers/PostMappings.cs
@@ -68,17 +68,3 @@ public class PostMappings : AutoMapper.Profile
 
 	private static Post NewPost(CoreOptions options) => new(options);
 }
-
-public class PublicKeyPemConverter : IValueResolver<SigningKey, PublicKeyDto, string>
-{
-	public string Resolve(SigningKey source, PublicKeyDto destination, string destMember, ResolutionContext context)
-	{
-		return source.Family switch
-		{
-			SigningKey.KeyFamily.Rsa => source.GetRsa().ExportSubjectPublicKeyInfoPem(),
-			SigningKey.KeyFamily.Dsa => source.GetDsa().ExportSubjectPublicKeyInfoPem(),
-			SigningKey.KeyFamily.EcDsa => source.GetEcDsa().ExportSubjectPublicKeyInfoPem(),
-			_ => null!,
-		};
-	}
-}

--- a/Source/Letterbook.Core/Models/Mappers/ProfileMappings.cs
+++ b/Source/Letterbook.Core/Models/Mappers/ProfileMappings.cs
@@ -1,5 +1,8 @@
-﻿using AutoMapper;
+﻿using System.Text;
+using AutoMapper;
 using Letterbook.Core.Models.Dto;
+using Org.BouncyCastle.Utilities.IO.Pem;
+using PemWriter = Org.BouncyCastle.OpenSsl.PemWriter;
 
 
 namespace Letterbook.Core.Models.Mappers;
@@ -9,16 +12,40 @@ public class ProfileMappings : AutoMapper.Profile
 	public ProfileMappings()
 	{
 		CreateMap<Models.Profile, FullProfileDto>(MemberList.Destination)
+			.ForMember(dto => dto.Followers, opt => opt.MapFrom(src => src.FollowersCount))
+			.ForMember(dto => dto.Following, opt => opt.MapFrom(src => src.FollowingCount))
 			.ForMember(dto => dto.Created, opt => opt.Ignore());
 		CreateMap<FullProfileDto, Models.Profile>(MemberList.Source)
 			.ForSourceMember(dto => dto.Updated, opt => opt.DoNotValidate())
 			.ForSourceMember(dto => dto.Created, opt => opt.DoNotValidate())
 			.ForSourceMember(dto => dto.Keys, opt => opt.DoNotValidate())
+			.ForSourceMember(dto => dto.Followers, opt => opt.DoNotValidate())
+			.ForSourceMember(dto => dto.Following, opt => opt.DoNotValidate())
+			.ForMember(profile => profile.Followers, opt => opt.Ignore())
+			.ForMember(profile => profile.Following, opt => opt.Ignore())
 			.ForMember(profile => profile.Updated, opt => opt.Ignore())
 			.ForMember(profile => profile.Keys, opt => opt.Ignore());
 		CreateMap<Models.Profile, MiniProfileDto>(MemberList.Destination);
 
-		CreateMap<Models.SigningKey, PublicKeyDto>()
-			.ForMember(dto => dto.PublicKeyPem, opt => opt.MapFrom<PublicKeyPemConverter>());
+		CreateMap<SigningKey, PublicKeyDto>()
+			.ConvertUsing(src => new PublicKeyDto
+			{
+				Label = src.Label,
+				Family = src.Family.ToString(),
+				PublicKeyPem = PemStringBuilder(src.PublicKey).ToString().Trim(),
+				Created = src.Created,
+				Expires = src.Expires,
+				FediId = src.FediId
+			});
+	}
+
+	private static StringBuilder PemStringBuilder(ReadOnlyMemory<byte> publicKey)
+	{
+		var builder = new StringBuilder();
+		using TextWriter writer = new StringWriter(builder);
+		var pemWriter = new PemWriter(writer);
+		var pem = new PemObject("PUBLIC KEY", publicKey.ToArray());
+		pemWriter.WriteObject(pem);
+		return builder;
 	}
 }

--- a/Source/Letterbook.Core/Models/Profile.cs
+++ b/Source/Letterbook.Core/Models/Profile.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Security.Claims;
+using EntityFrameworkCore.Projectables;
 using Letterbook.Core.Extensions;
 using Letterbook.Core.Values;
 using Letterbook.Generators;
@@ -144,14 +145,16 @@ public class Profile : IFederatedActor, IEquatable<Profile>
 	public string Description { get; set; }
 	public CustomField[] CustomFields { get; set; } = [];
 	public DateTimeOffset Created { get; set; } = DateTimeOffset.UtcNow;
-	public DateTime Updated { get; set; } = DateTime.UtcNow;
+	public DateTimeOffset Updated { get; set; } = DateTimeOffset.UtcNow;
 	public Account? OwnedBy { get; set; }
 	public ICollection<ProfileClaims> Accessors { get; set; } = new HashSet<ProfileClaims>();
 	public ActivityActorType Type { get; set; }
 	public ICollection<Audience> Headlining { get; set; } = new HashSet<Audience>();
 	public ICollection<Audience> Audiences { get; set; } = new HashSet<Audience>();
 	public IList<FollowerRelation> FollowersCollection { get; set; } = new List<FollowerRelation>();
+	[Projectable] public int FollowersCount => FollowersCollection.Count;
 	public IList<FollowerRelation> FollowingCollection { get; set; } = new List<FollowerRelation>();
+	[Projectable] public int FollowingCount => FollowingCollection.Count;
 	public IList<SigningKey> Keys { get; set; } = new List<SigningKey>();
 	/// This Profile was the subject of these Reports
 	public ICollection<ModerationReport> ReportSubject = new HashSet<ModerationReport>();
@@ -288,6 +291,18 @@ public class Profile : IFederatedActor, IEquatable<Profile>
 		var relation = FollowersCollection.FirstOrDefault(relation => relation.Follower == target,
 			new FollowerRelation(target, this, FollowState.None));
 		return relation.State == FollowState.Blocked;
+	}
+
+	public FollowState HasFollower(Profile target)
+	{
+		return FollowersCollection.FirstOrDefault(relation => relation.Follower == target,
+			new FollowerRelation(target, this, FollowState.None)).State;
+	}
+
+	public FollowState IsFollowing(Profile target)
+	{
+		return FollowingCollection.FirstOrDefault(relation => relation.Follower == target,
+			new FollowerRelation(target, this, FollowState.None)).State;
 	}
 
 	// Eventually: CreateGroup, CreateBot, Mayyyyyybe CreateService?

--- a/Source/Letterbook.Core/Models/Profile.cs
+++ b/Source/Letterbook.Core/Models/Profile.cs
@@ -131,6 +131,10 @@ public class Profile : IFederatedActor, IEquatable<Profile>
 	public static Profile AddInstanceProfile(Profile instance) => SystemProfiles[SystemInstanceId] = instance;
 	public static Profile? GetInstanceProfile() => SystemProfiles.GetValueOrDefault(SystemInstanceId);
 
+	/***
+	 * Properties
+	 */
+
 	public ProfileId Id { get; set; }
 
 	public Uri FediId { get; set; }
@@ -152,9 +156,7 @@ public class Profile : IFederatedActor, IEquatable<Profile>
 	public ICollection<Audience> Headlining { get; set; } = new HashSet<Audience>();
 	public ICollection<Audience> Audiences { get; set; } = new HashSet<Audience>();
 	public IList<FollowerRelation> FollowersCollection { get; set; } = new List<FollowerRelation>();
-	[Projectable] public int FollowersCount => FollowersCollection.Count(relation => relation.State == FollowState.Accepted);
 	public IList<FollowerRelation> FollowingCollection { get; set; } = new List<FollowerRelation>();
-	[Projectable] public int FollowingCount => FollowingCollection.Count(relation => relation.State == FollowState.Accepted);
 	public IList<SigningKey> Keys { get; set; } = new List<SigningKey>();
 	/// This Profile was the subject of these Reports
 	public ICollection<ModerationReport> ReportSubject = new HashSet<ModerationReport>();
@@ -162,6 +164,12 @@ public class Profile : IFederatedActor, IEquatable<Profile>
 	public ICollection<ModerationReport> Reports = new HashSet<ModerationReport>();
 	public IDictionary<Restrictions, DateTimeOffset> Restrictions { get; set; } = new Dictionary<Restrictions, DateTimeOffset>();
 
+	/***
+	 * Computed properties and projections
+	 */
+
+	[Projectable] public int FollowersCount => FollowersCollection.Count(relation => relation.State == FollowState.Accepted);
+	[Projectable] public int FollowingCount => FollowingCollection.Count(relation => relation.State == FollowState.Accepted);
 	public IEnumerable<Claim> RestrictionClaims() => Restrictions
 		.Where(r => r.Value >= DateTimeOffset.UtcNow)
 		.Select(pair => new Claim(pair.Key.ToString(), "true"));
@@ -187,6 +195,10 @@ public class Profile : IFederatedActor, IEquatable<Profile>
 
 		return this;
 	}
+
+	/***
+	 * Behavior
+	 */
 
 	public FollowerRelation AddFollower(Profile follower, FollowState state)
 	{

--- a/Source/Letterbook.Core/Models/Profile.cs
+++ b/Source/Letterbook.Core/Models/Profile.cs
@@ -157,12 +157,16 @@ public class Profile : IFederatedActor, IEquatable<Profile>
 	public ICollection<Audience> Audiences { get; set; } = new HashSet<Audience>();
 	public IList<FollowerRelation> FollowersCollection { get; set; } = new List<FollowerRelation>();
 	public IList<FollowerRelation> FollowingCollection { get; set; } = new List<FollowerRelation>();
+	public int FollowersEstimate { get; set; } = -1;
+	public int FollowingEstimate { get; set; } = -1;
 	public IList<SigningKey> Keys { get; set; } = new List<SigningKey>();
 	/// This Profile was the subject of these Reports
 	public ICollection<ModerationReport> ReportSubject = new HashSet<ModerationReport>();
 	/// This Profile submitted these Reports
 	public ICollection<ModerationReport> Reports = new HashSet<ModerationReport>();
 	public IDictionary<Restrictions, DateTimeOffset> Restrictions { get; set; } = new Dictionary<Restrictions, DateTimeOffset>();
+	public IList<Post> Posts { get; set; } = new List<Post>();
+	public int PostsEstimate { get; set; } = -1;
 
 	/***
 	 * Computed properties and projections
@@ -170,6 +174,7 @@ public class Profile : IFederatedActor, IEquatable<Profile>
 
 	[Projectable] public int FollowersCount => FollowersCollection.Count(relation => relation.State == FollowState.Accepted);
 	[Projectable] public int FollowingCount => FollowingCollection.Count(relation => relation.State == FollowState.Accepted);
+	[Projectable] public int PostsCount => Posts.Count;
 	public IEnumerable<Claim> RestrictionClaims() => Restrictions
 		.Where(r => r.Value >= DateTimeOffset.UtcNow)
 		.Select(pair => new Claim(pair.Key.ToString(), "true"));

--- a/Source/Letterbook.Core/Models/Profile.cs
+++ b/Source/Letterbook.Core/Models/Profile.cs
@@ -152,9 +152,9 @@ public class Profile : IFederatedActor, IEquatable<Profile>
 	public ICollection<Audience> Headlining { get; set; } = new HashSet<Audience>();
 	public ICollection<Audience> Audiences { get; set; } = new HashSet<Audience>();
 	public IList<FollowerRelation> FollowersCollection { get; set; } = new List<FollowerRelation>();
-	[Projectable] public int FollowersCount => FollowersCollection.Count;
+	[Projectable] public int FollowersCount => FollowersCollection.Count(relation => relation.State == FollowState.Accepted);
 	public IList<FollowerRelation> FollowingCollection { get; set; } = new List<FollowerRelation>();
-	[Projectable] public int FollowingCount => FollowingCollection.Count;
+	[Projectable] public int FollowingCount => FollowingCollection.Count(relation => relation.State == FollowState.Accepted);
 	public IList<SigningKey> Keys { get; set; } = new List<SigningKey>();
 	/// This Profile was the subject of these Reports
 	public ICollection<ModerationReport> ReportSubject = new HashSet<ModerationReport>();

--- a/Tests/Letterbook.IntegrationTests/DataAdapterTests.cs
+++ b/Tests/Letterbook.IntegrationTests/DataAdapterTests.cs
@@ -35,7 +35,7 @@ public sealed class DataAdapterTests : IClassFixture<HostFixture<DataAdapterTest
 	private List<Account> _accounts;
 	private readonly IServiceScope _scope;
 	private readonly Mapper _mapper;
-	private readonly MappingConfigProvider _mappngProvider;
+	private readonly MappingConfigProvider _mappingProvider;
 	static int? ITestSeed.Seed() => null;
 
 	public DataAdapterTests(ITestOutputHelper output, HostFixture<DataAdapterTests> host)
@@ -49,8 +49,8 @@ public sealed class DataAdapterTests : IClassFixture<HostFixture<DataAdapterTest
 		_context = _host.CreateContext(_scope);
 		_actual = _host.CreateContext(_scope);
 		_adapter = new DataAdapter(Mock.Of<ILogger<DataAdapter>>(), _context);
-		_mappngProvider = new MappingConfigProvider(Options.Create(new CoreOptions()));
-		_mapper = new Mapper(_mappngProvider.Profiles);
+		_mappingProvider = new MappingConfigProvider(Options.Create(new CoreOptions()));
+		_mapper = new Mapper(_mappingProvider.Profiles);
 	}
 
 	[Fact]
@@ -89,7 +89,7 @@ public sealed class DataAdapterTests : IClassFixture<HostFixture<DataAdapterTest
 	public async Task QueryProfileProjections()
 	{
 		var projected = await _adapter.Profiles(_profiles[7].Id).Select(e => new {Followers = e.FollowersCount}).FirstAsync();
-		var automapProjected = await _adapter.Profiles(_profiles[7].Id).ProjectTo<FullProfileDto>(_mappngProvider.Profiles).FirstAsync();
+		var automapProjected = await _adapter.Profiles(_profiles[7].Id).ProjectTo<FullProfileDto>(_mappingProvider.Profiles).FirstAsync();
 		var notProjected = await _adapter.Profiles(_profiles[7].Id).FirstAsync();
 
 		Assert.Equal(4, projected.Followers);

--- a/Tests/Letterbook.IntegrationTests/DataAdapterTests.cs
+++ b/Tests/Letterbook.IntegrationTests/DataAdapterTests.cs
@@ -88,12 +88,13 @@ public sealed class DataAdapterTests : IClassFixture<HostFixture<DataAdapterTest
 	[Fact(DisplayName = "Query profile projection fields")]
 	public async Task QueryProfileProjections()
 	{
-		var projected = await _adapter.Profiles(_profiles[7].Id).Select(e => new {Followers = e.FollowersCount}).FirstAsync();
-		var automapProjected = await _adapter.Profiles(_profiles[7].Id).ProjectTo<FullProfileDto>(_mappingProvider.Profiles).FirstAsync();
-		var notProjected = await _adapter.Profiles(_profiles[7].Id).FirstAsync();
+		var id = _profiles[7].Id;
+		var adHocProjection = await _adapter.Profiles(id).Select(e => new {Followers = e.FollowersCount}).FirstAsync();
+		var automapProjection = await _adapter.Profiles(id).ProjectTo<FullProfileDto>(_mappingProvider.Profiles).FirstAsync();
+		var noProjection = await _adapter.Profiles(id).FirstAsync();
 
-		Assert.Equal(4, projected.Followers);
-		Assert.Equal(4, automapProjected.Followers);
-		Assert.Equal(0, notProjected.FollowersCount);
+		Assert.True(adHocProjection.Followers >= 4);
+		Assert.True(automapProjection.Followers >= 4);
+		Assert.Equal(0, noProjection.FollowersCount);
 	}
 }

--- a/docs/OpenApi/letterbook-v1.json
+++ b/docs/OpenApi/letterbook-v1.json
@@ -3668,11 +3668,6 @@
             },
             "nullable": true
           },
-          "followersCount": {
-            "type": "integer",
-            "format": "int32",
-            "readOnly": true
-          },
           "followingCollection": {
             "type": "array",
             "items": {
@@ -3680,10 +3675,13 @@
             },
             "nullable": true
           },
-          "followingCount": {
+          "followersEstimate": {
             "type": "integer",
-            "format": "int32",
-            "readOnly": true
+            "format": "int32"
+          },
+          "followingEstimate": {
+            "type": "integer",
+            "format": "int32"
           },
           "keys": {
             "type": "array",
@@ -3746,6 +3744,32 @@
             },
             "additionalProperties": false,
             "nullable": true
+          },
+          "posts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Post"
+            },
+            "nullable": true
+          },
+          "postsEstimate": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "followersCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "followingCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "postsCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
           }
         },
         "additionalProperties": false

--- a/docs/OpenApi/letterbook-v1.json
+++ b/docs/OpenApi/letterbook-v1.json
@@ -2892,6 +2892,14 @@
               "$ref": "#/components/schemas/PublicKeyDto"
             },
             "nullable": true
+          },
+          "followers": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "following": {
+            "type": "integer",
+            "format": "int32"
           }
         },
         "additionalProperties": false
@@ -3660,12 +3668,22 @@
             },
             "nullable": true
           },
+          "followersCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
           "followingCollection": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/FollowerRelation"
             },
             "nullable": true
+          },
+          "followingCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
           },
           "keys": {
             "type": "array",


### PR DESCRIPTION
Configures projections to begin to support querying complex and aggregate values. Also adds simple estimates, to track values that may be reported by peer instances.

## Details
- Adds projectable library, and some initial projectable methods
  - Projections aren't all that useful on basic model objects, but they can be used to populate values on mapped or projected objects
  - Automapper configs can sometimes be used as projection targets, which is helpful, and can make code reuse easier.
  - But only if the mapping doesn't use several techniques that we do tend to rely on. As a rule of thumb, prefer `ConvertUsing(expr)` methods, rather than value mappers or resolvers.
  - See the AutoMapper docs for details on restrictions when using projectionshttps://docs.automapper.org/en/stable/Queryable-Extensions.html#supported-mapping-options
- Estimated fields may or may not be populated
  - On remote objects, check if they are and use the reported value if we have one
  - We don't currently fetch those values from anywhere.
  - They likely need to be crawled from links on peer profiles.
  - Post-related estimates may sometimes be available on the object, without crawling the relevant collections.
  - But we would still likely crawl many of those collections, in many scenarios.

## Related
- prep for #353 
