### PR TITLE
adjust implementation to always use Unix line endings

### DIFF
--- a/Source/Letterbook.Core/Models/Mappers/ProfileMappings.cs
+++ b/Source/Letterbook.Core/Models/Mappers/ProfileMappings.cs
@@ -32,7 +32,7 @@ public class ProfileMappings : AutoMapper.Profile
 			{
 				Label = src.Label,
 				Family = src.Family.ToString(),
-				PublicKeyPem = PemStringBuilder(src.PublicKey).ToString().Trim(),
+				PublicKeyPem = PemStringBuilder(src.PublicKey).ToString().Trim().ReplaceLineEndings("\n"),
 				Created = src.Created,
 				Expires = src.Expires,
 				FediId = src.FediId


### PR DESCRIPTION
This ensures tests all pass on Windows.

```
$ dotnet test Tests/Letterbook.Core.Tests/
Restore complete (1.1s)
  Letterbook.Generators net9.0 succeeded (0.4s) → artifacts\bin\Letterbook.Generators\debug_net9.0\Letterbook.Generators.dll
  Letterbook.Core succeeded (7.0s) → artifacts\bin\Letterbook.Core\debug\Letterbook.Core.dll
  Letterbook.Adapter.Db succeeded (6.6s) → artifacts\bin\Letterbook.Adapter.Db\debug\Letterbook.Adapter.Db.dll
  Letterbook.Core.Tests succeeded (2.4s) → artifacts\bin\Letterbook.Core.Tests\debug\Letterbook.Core.Tests.dll
[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v3.1.5+1b188a7b0a (64-bit .NET 9.0.11)
[xUnit.net 00:00:00.16]   Discovering: Letterbook.Core.Tests
[xUnit.net 00:00:00.25]   Discovered:  Letterbook.Core.Tests
[xUnit.net 00:00:00.31]   Starting:    Letterbook.Core.Tests
[xUnit.net 00:00:04.07]   Finished:    Letterbook.Core.Tests
  Letterbook.Core.Tests test succeeded (5.9s)

Test summary: total: 162, failed: 0, succeeded: 162, skipped: 0, duration: 5.8s
Build succeeded in 24.6s
```

## Related
- https://github.com/Letterbook/Letterbook/issues/447
