### PR TITLE
Fix/timeline

### DIFF
--- a/Source/Letterbook.Core/ITimelineService.cs
+++ b/Source/Letterbook.Core/ITimelineService.cs
@@ -15,5 +15,5 @@ public interface IAuthzTimelineService
 	public Task HandleShare(Post post, Profile sharedBy);
 	public Task HandleUpdate(Post post, Post oldPost);
 	public Task HandleDelete(Post note);
-	public Task<IEnumerable<Post>> GetFeed(Uuid7 profileId, DateTimeOffset begin, int limit = 40);
+	public Task<IEnumerable<Post>> GetFeed(ProfileId profileId, DateTimeOffset begin, int limit = 40);
 }

--- a/Source/Letterbook.Core/Queries/PostQueries.cs
+++ b/Source/Letterbook.Core/Queries/PostQueries.cs
@@ -25,4 +25,15 @@ public static class PostQueries
 			.Include(p => p.Audience)
 			.Include(p => p.Contents)
 			.AsSplitQuery();
+
+	/// <summary>
+	/// Include necessary data to fill out a feed
+	/// </summary>
+	/// <param name="query"></param>
+	/// <returns></returns>
+	public static IQueryable<Post> WithTimelineFields(this IQueryable<Post> query) =>
+		query.WithCommonFields()
+			.Include(p => p.AddressedTo).ThenInclude(m => m.Subject)
+			.AsSplitQuery()
+			.AsNoTrackingWithIdentityResolution();
 }

--- a/Source/Letterbook.Web/Pages/Index.cshtml.cs
+++ b/Source/Letterbook.Web/Pages/Index.cshtml.cs
@@ -8,19 +8,22 @@ public class IndexModel : PageModel
 {
 	private ITimelineService _timeline;
 	private readonly IProfileService _profiles;
+	private readonly IPostService _posts;
 	private readonly ILogger<IndexModel> _logger;
 
 	public IOptions<CoreOptions> Opts { get; }
 	public Models.Profile Self { get; set; } = default!;
 	public IAuthzTimelineService Timeline { get; set; } = default!;
 	public IAuthzProfileService Profiles { get; set; } = default!;
+	public IAuthzPostService Posts { get; set; } = default!;
 	public string? SelfId => User.Claims.FirstOrDefault(c => c.Type == ApplicationClaims.ActiveProfile)?.Value;
 
-	public IndexModel(ILogger<IndexModel> logger, IOptions<CoreOptions> opts, ITimelineService timeline, IProfileService profiles)
+	public IndexModel(ILogger<IndexModel> logger, IOptions<CoreOptions> opts, ITimelineService timeline, IProfileService profiles, IPostService posts)
 	{
 		Opts = opts;
 		_timeline = timeline;
 		_profiles = profiles;
+		_posts = posts;
 		_logger = logger;
 	}
 
@@ -28,6 +31,7 @@ public class IndexModel : PageModel
 	{
 		Timeline = _timeline.As(User.Claims);
 		Profiles = _profiles.As(User.Claims);
+		Posts = _posts.As(User.Claims);
 		if (Models.ProfileId.TryParse(SelfId, out var id) && await Profiles.LookupProfile(id) is {} self)
 		{
 			Self = self;
@@ -35,5 +39,5 @@ public class IndexModel : PageModel
 	}
 
 	// TODO: figure out what to do for anonymous feed/homepage?
-	public Task<IEnumerable<Models.Post>> GetPosts() => Timeline.GetFeed(Self.GetId(), DateTimeOffset.UtcNow);
+	public Task<IEnumerable<Models.Post>> GetPosts() => Timeline.GetFeed(Self.Id, DateTimeOffset.UtcNow);
 }

--- a/Tests/Letterbook.Web.Mocks/MockTimelineService.cs
+++ b/Tests/Letterbook.Web.Mocks/MockTimelineService.cs
@@ -37,7 +37,7 @@ public class MockTimelineService : ITimelineService, IAuthzTimelineService
 	{
 		return _timelineService.HandleDelete(note);
 	}
-	public Task<IEnumerable<Models.Post>> GetFeed(Uuid7 profileId, DateTimeOffset begin, int limit = 40)
+	public Task<IEnumerable<Models.Post>> GetFeed(Models.ProfileId profileId, DateTimeOffset begin, int limit = 40)
 	{
 		_log.LogInformation("Called the mock service");
 		var result = Enumerable.Range(0, limit)


### PR DESCRIPTION
Fixes timeline rendering. It's been broken for a while.

## Details
- This requires 3 db lookups and a potentially very large WHERE IN clause
- We're going to need to manage audience memberships in the feeds db sooner than not, so we can join on membership instead of doing WHERE IN

<img width="1012" height="491" alt="A timeline in local dev with 2 whole posts in it" src="https://github.com/user-attachments/assets/d279dab9-4066-4240-92e4-250f8f37afa0" />