### PR TITLE
fix timelines test

### DIFF
--- a/Tests/Letterbook.IntegrationTests/Fixtures/HostFixture.cs
+++ b/Tests/Letterbook.IntegrationTests/Fixtures/HostFixture.cs
@@ -179,6 +179,7 @@ public class HostFixture<T> : WebApplicationFactory<Program>
 		_context.SaveChanges();
 
 		_context.Posts.AddRange(Posts.SelectMany(pair => pair.Value));
+		_context.Posts.AddRange(Timeline);
 		_context.SaveChanges();
 
 		_context.ModerationPolicy.AddRange(Policies);
@@ -399,7 +400,7 @@ public class HostFixture<T> : WebApplicationFactory<Program>
 			// Pick or add new Creator
 			if (Profiles.Count > 0 && faker.Random.Bool(0.9f))
 			{
-				creator = faker.PickRandom(Profiles);
+				creator = faker.PickRandom(Profiles[3..7]);
 			}
 			else
 			{

--- a/Tests/Letterbook.IntegrationTests/TimelinesApiTests.cs
+++ b/Tests/Letterbook.IntegrationTests/TimelinesApiTests.cs
@@ -5,10 +5,8 @@ using System.Text.Json.Serialization;
 using Letterbook.Core.Extensions;
 using Letterbook.Core.Models.Dto;
 using Letterbook.Core.Models.Mappers.Converters;
-using Letterbook.Core.Values;
 using Letterbook.IntegrationTests.Fixtures;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.EntityFrameworkCore;
 
 namespace Letterbook.IntegrationTests;
 
@@ -56,10 +54,10 @@ public class TimelinesApiTests : IClassFixture<HostFixture<TimelinesApiTests>>, 
 	{
 		var response = await _client.GetAsync($"/lb/v1/timelines/{_host.Profiles[0].GetId25()}");
 
-		Assert.NotNull(response);
-		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-		var actual = Assert.IsAssignableFrom<IEnumerable<PostDto>>(
-			await response.Content.ReadFromJsonAsync<IEnumerable<PostDto>>(_json));
+			Assert.NotNull(response);
+			Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+			var actual = Assert.IsAssignableFrom<IEnumerable<PostDto>>(
+				await response.Content.ReadFromJsonAsync<IEnumerable<PostDto>>(_json));
 
 		Assert.NotEmpty(actual);
 	}


### PR DESCRIPTION
Fixes timelines integration tests that were failing due to inconsistent test data setup