### PR TITLE
nodeinfo controller

### DIFF
--- a/Http/Endpoints.http
+++ b/Http/Endpoints.http
@@ -12,3 +12,8 @@ Accept: application/ld+json; profile="https://www.w3.org/ns/activitystreams"
 ### Webfinger Peer
 GET {{peer}}/.well-known/webfinger?resource=acct:{{peer_user}}@{{peer_domain}} 
 
+### Nodeinfo
+GET {{host}}/.well-known/nodeinfo
+
+### Nodeinfo
+GET {{host}}/node_info/2.1

--- a/Source/Letterbook.Api/NodeInfo/NodeInfo.cs
+++ b/Source/Letterbook.Api/NodeInfo/NodeInfo.cs
@@ -1,0 +1,51 @@
+namespace Letterbook.Api.NodeInfo;
+
+public class NodeInfo
+{
+	public string Version { get; set; } = "2.1";
+	public bool OpenRegistration { get; set; } = false;
+	public Dictionary<string, string> Metadata { get; set; } = new();
+	public List<string> Protocols { get; set; } = ["activitypub"];
+	public Software Software { get; set; } = new();
+}
+
+public class Software
+{
+	public string Name { get; set; } = "Letterbook";
+	public string Version { get; set; } = "0.0.0-0.sup";
+	public string Repository { get; set; } = "https://github.com/letterbook/letterbook";
+	public string Homepage { get; set; } = "https://letterbook.com";
+	public Usage Usage { get; set; } = new();
+	public Services Services { get; set; } = new();
+}
+
+public class Services
+{
+	public List<string> Inbound { get; set; } = [];
+	public List<string> Outbound { get; set; } = [];
+}
+
+public class Usage
+{
+	public int LocalPosts { get; set; }
+	public int LocalComments { get; set; }
+	public Users Users { get; set; } = new();
+}
+
+public class Users
+{
+	public int Total { get; set; }
+	public int ActiveHalfYear { get; set; }
+	public int ActiveMonth { get; set; }
+}
+
+public class NodeInfoLinks
+{
+	public List<Link> Links { get; set; } = [];
+}
+
+public class Link
+{
+	public string Rel { get; set; } = "http://nodeinfo.diaspora.software/ns/schema/2.1";
+	public required string Href { get; set; }
+}

--- a/Source/Letterbook.Api/NodeInfo/NodeInfoController.cs
+++ b/Source/Letterbook.Api/NodeInfo/NodeInfoController.cs
@@ -1,0 +1,30 @@
+using Letterbook.Core;
+using Letterbook.Core.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+namespace Letterbook.Api.NodeInfo;
+
+[ApiExplorerSettings(IgnoreApi = true)]
+public class NodeInfoController(IOptions<CoreOptions> opts) : ControllerBase
+{
+
+	[HttpGet("/.well-known/nodeinfo")]
+	public IActionResult Index()
+	{
+		var links = new NodeInfoLinks();
+		links.Links.Add(new()
+		{
+			Href = opts.Value.BaseUri() + "node_info/2.1"
+		});
+		return Ok(links);
+	}
+
+	[HttpGet("[controller]/2.1")]
+	public IActionResult NodeInfo()
+	{
+		var info = new NodeInfo();
+
+		return Ok(info);
+	}
+}


### PR DESCRIPTION
Adds minimal support for NodeInfo protocol

## Details
- This is a bit of a quick hack, but it's enough that other software can use it as a heuristic if they need to
- the more socially informative bits like post and user counts can come later

## Related
- closes #39