### PR TITLE
Issues/486 get search profiles to return results locally

### DIFF
--- a/Source/Letterbook.Adapter.Db/DataAdapter.cs
+++ b/Source/Letterbook.Adapter.Db/DataAdapter.cs
@@ -314,7 +314,7 @@ public class DataAdapter : IDataAdapter, IAsyncDisposable, ISearchProvider
 		// @handle@host
 		if (UriExtensions.TryParseHandle(query, out var handle, out var host))
 		{
-			var handles = await _context.Profiles.Where(p => p.Handle == local && p.Authority == opts.BaseUri().GetAuthority()).Take(limit)
+			var handles = await _context.Profiles.Where(p => p.Handle == handle && p.Authority == opts.BaseUri().GetAuthority()).Take(limit)
 				.TagWith("search")
 				.ToListAsync(cancel);
 			limit -= handles.Count;

--- a/Source/Letterbook.Core/Extensions/UriExtensions.cs
+++ b/Source/Letterbook.Core/Extensions/UriExtensions.cs
@@ -41,8 +41,8 @@ public static partial class UriExtensions
 		    builder.Path != "/" ||
 		    !string.IsNullOrEmpty(builder.Password) ||
 		    !string.IsNullOrEmpty(builder.Query) ||
-		    !builder.Uri.IsDefaultPort ||
-		    builder.Uri.IsLoopback ||
+		    // !builder.Uri.IsDefaultPort ||
+		    // builder.Uri.IsLoopback ||
 		    builder.Uri.HostNameType != UriHostNameType.Dns)
 		{
 			handle = null;

--- a/Tests/Letterbook.IntegrationTests/DataAdapterTests.cs
+++ b/Tests/Letterbook.IntegrationTests/DataAdapterTests.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
+using OpenIddict.Abstractions;
 using Xunit.Abstractions;
 
 namespace Letterbook.IntegrationTests;
@@ -96,5 +97,35 @@ public sealed class DataAdapterTests : IClassFixture<HostFixture<DataAdapterTest
 		Assert.True(adHocProjection.Followers >= 4);
 		Assert.True(automapProjection.Followers >= 4);
 		Assert.Equal(0, noProjection.FollowersCount);
+	}
+
+	[Fact(DisplayName = "Search profile example: @handle")]
+	public async Task ProfileSearchExamples()
+	{
+		var localProfile = _profiles[0];
+
+		Assert.Single(
+			await _adapter.SearchProfiles(
+				$"@{localProfile.Handle}", CancellationToken.None, new CoreOptions
+				{
+					DomainName = "localhost",
+					Scheme = "http",
+					Port = "5127"
+				}));
+	}
+
+	[Fact(DisplayName = "Search profile example: @handle@host")]
+	public async Task ProfileSearchExamplesHandleAndHost()
+	{
+		var localProfile = _profiles[0];
+
+		Assert.Single(
+			await _adapter.SearchProfiles(
+				$"@{localProfile.Handle}@{localProfile.Authority}", CancellationToken.None, new CoreOptions
+				{
+					DomainName = "localhost",
+					Scheme = "http",
+					Port = "5127"
+				}));
 	}
 }


### PR DESCRIPTION
As part of another ticket I am trying to very that I can search for profiles with `DataAdapter`.

I am having trouble with that because local profiles are never being returned due to validation in `UriExtensions.TryParseHandle` and I think a typo in `DataAdapter.SearchProfilesData`.

The typo is corrected in 77c8533aab133f313303b1f0301adc1cd260f057 but it's more 6c33dc378d1720075eff6fd159922f4534d74e32 that I need help with.

It has these two guards which are preventing local profiles from working:

```
commit 6c33dc378d1720075eff6fd159922f4534d74e32
Author: Ben Biddington <ben.biddington@gmail.com>
Date:   Sun Feb 22 14:35:39 2026 +1300

    Prefactor: relax validation otherwise test profile can never work.

    I don't know how OK this is.

diff --git a/Source/Letterbook.Core/Extensions/UriExtensions.cs b/Source/Letterbook.Core/Extensions/UriExtensions.cs
index 38e0590..8c49dea 100644
--- a/Source/Letterbook.Core/Extensions/UriExtensions.cs
+++ b/Source/Letterbook.Core/Extensions/UriExtensions.cs
@@ -41,8 +41,8 @@ public static partial class UriExtensions
                    builder.Path != "/" ||
                    !string.IsNullOrEmpty(builder.Password) ||
                    !string.IsNullOrEmpty(builder.Query) ||
-                   !builder.Uri.IsDefaultPort ||
-                   builder.Uri.IsLoopback ||
+                   // !builder.Uri.IsDefaultPort ||
+                   // builder.Uri.IsLoopback ||
                    builder.Uri.HostNameType != UriHostNameType.Dns)
                {
                        handle = null;
```

because local profiles have `localhost:5127` as their authority.

## Related
- https://github.com/Letterbook/Letterbook/issues/486
